### PR TITLE
fix: Style option elements matching current theme

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,11 @@ export default function Header() {
               }
             >
               {models.map((m) => (
-                <option key={m.id} value={m.id} className="bg-base-100 text-base-content">
+                <option
+                  key={m.id}
+                  value={m.id}
+                  className="bg-base-300 text-base-content"
+                >
                   {m.name}
                 </option>
               ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ export default function Header() {
               }
             >
               {models.map((m) => (
-                <option key={m.id} value={m.id}>
+                <option key={m.id} value={m.id} className="bg-base-100 text-base-content">
                   {m.name}
                 </option>
               ))}

--- a/src/components/SettingDialog.tsx
+++ b/src/components/SettingDialog.tsx
@@ -811,7 +811,7 @@ const SettingsModalDropdown: React.FC<{
           disabled={disabled}
         >
           {options.map((p) => (
-            <option key={p.key} value={p.key}>
+            <option key={p.key} value={p.key} className="bg-base-100 text-base-content">
               {p.value}
             </option>
           ))}

--- a/src/components/SettingDialog.tsx
+++ b/src/components/SettingDialog.tsx
@@ -811,7 +811,11 @@ const SettingsModalDropdown: React.FC<{
           disabled={disabled}
         >
           {options.map((p) => (
-            <option key={p.key} value={p.key} className="bg-base-100 text-base-content">
+            <option
+              key={p.key}
+              value={p.key}
+              className="bg-base-100 text-base-content"
+            >
               {p.value}
             </option>
           ))}


### PR DESCRIPTION
Before:

<img width="351" height="173" alt="image" src="https://github.com/user-attachments/assets/358213ee-084f-41b1-88fe-b72b04a04190" />


After:

<img width="353" height="177" alt="image" src="https://github.com/user-attachments/assets/8d50cb79-439a-4cb4-82e6-04de63ea717f" />

