### PR TITLE
ui(icon): Replace @heroicons/react with lucide-react #119

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.22.5",
       "license": "MIT",
       "dependencies": {
-        "@heroicons/react": "^2.2.0",
         "@sec-ant/readable-stream": "^0.6.0",
         "dexie": "^4.0.11",
         "highlight.js": "^11.10.0",
         "i18next": "^25.5.2",
         "i18next-browser-languagedetector": "^8.2.0",
         "katex": "^0.16.15",
+        "lucide-react": "^0.544.0",
         "pdfjs-dist": "^5.2.133",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2240,15 +2240,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -6972,6 +6963,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "preview": "npm run build && vite preview"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
     "@sec-ant/readable-stream": "^0.6.0",
     "dexie": "^4.0.11",
     "highlight.js": "^11.10.0",
     "i18next": "^25.5.2",
     "i18next-browser-languagedetector": "^8.2.0",
     "katex": "^0.16.15",
+    "lucide-react": "^0.544.0",
     "pdfjs-dist": "^5.2.133",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/CanvasPyInterpreter.tsx
+++ b/src/components/CanvasPyInterpreter.tsx
@@ -1,4 +1,4 @@
-import { PlayIcon, StopIcon } from '@heroicons/react/24/outline';
+import { Play, Square } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useChatContext } from '../context/chat';
@@ -170,7 +170,7 @@ export default function CanvasPyInterpreter() {
                 onClick={() => runCode(code)}
                 disabled={running}
               >
-                <PlayIcon className="h-6 w-6" />{' '}
+                <Play className="h-6 w-6" />{' '}
                 {t('codeRunner.canvasPyInterpreter.buttons.run')}
               </button>
               {showStopBtn && (
@@ -178,7 +178,7 @@ export default function CanvasPyInterpreter() {
                   className="btn btn-sm bg-base-100 ml-2"
                   onClick={() => interruptFn?.()}
                 >
-                  <StopIcon className="h-6 w-6" />{' '}
+                  <Square className="h-6 w-6" />{' '}
                   {t('codeRunner.canvasPyInterpreter.buttons.stop')}
                 </button>
               )}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,9 +1,4 @@
-import {
-  AdjustmentsHorizontalIcon,
-  ArrowUpIcon,
-  PaperClipIcon,
-  StopIcon,
-} from '@heroicons/react/24/solid';
+import { ArrowUp, Paperclip, Settings2, Square } from 'lucide-react';
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -128,7 +123,7 @@ export function ChatInput({
                 tabIndex={0}
                 role="button"
               >
-                <PaperClipIcon className="h-5 w-5" />
+                <Paperclip className="h-5 w-5" />
               </label>
 
               <button
@@ -137,7 +132,7 @@ export function ChatInput({
                 aria-label={t('header.ariaLabels.settings')}
                 onClick={() => navigate('/settings')}
               >
-                <AdjustmentsHorizontalIcon className="h-5 w-5" />
+                <Settings2 className="h-5 w-5" />
               </button>
             </div>
 
@@ -147,7 +142,7 @@ export function ChatInput({
                   className="btn btn-neutral w-8 h-8 p-0 rounded-full"
                   onClick={onStop}
                 >
-                  <StopIcon className="h-5 w-5" />
+                  <Square className="h-4 w-4" fill="currentColor" />
                 </button>
               )}
 
@@ -157,7 +152,7 @@ export function ChatInput({
                   onClick={sendNewMessage}
                   aria-label={t('chatInput.ariaLabels.send')}
                 >
-                  <ArrowUpIcon className="h-5 w-5" />
+                  <ArrowUp className="h-5 w-5" />
                 </button>
               )}
             </div>

--- a/src/components/ChatInputExtraContextItem.tsx
+++ b/src/components/ChatInputExtraContextItem.tsx
@@ -1,8 +1,4 @@
-import {
-  DocumentTextIcon,
-  SpeakerWaveIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline';
+import { FileText, Volume2, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MessageExtra } from '../types';
@@ -49,7 +45,7 @@ export default function ChatInputExtraContextItem({
                 className="btn btn-neutral btn-sm w-4 h-4 p-0 rounded-full"
                 onClick={() => removeItem(i)}
               >
-                <XMarkIcon className="h-3 w-3" />
+                <X className="h-3 w-3" />
               </button>
             </div>
           )}
@@ -75,9 +71,9 @@ export default function ChatInputExtraContextItem({
                   aria-description={t('chatInput.ariaLabels.documentIcon')}
                 >
                   {item.type === 'audioFile' ? (
-                    <SpeakerWaveIcon className="h-8 w-8 text-gray-500" />
+                    <Volume2 className="h-8 w-8 text-gray-500" />
                   ) : (
-                    <DocumentTextIcon className="h-8 w-8 text-gray-500" />
+                    <FileText className="h-8 w-8 text-gray-500" />
                   )}
                 </div>
 
@@ -104,7 +100,7 @@ export default function ChatInputExtraContextItem({
                 className="btn btn-ghost btn-sm"
                 aria-label={t('chatInput.previewDialog.closeButton')}
               >
-                <XMarkIcon className="h-5 w-5" onClick={() => setShow(-1)} />
+                <X className="h-5 w-5" onClick={() => setShow(-1)} />
               </button>
             </div>
             {showingItem.type === 'imageFile' ? (

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,17 +1,18 @@
 import {
-  ArrowPathIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  CubeTransparentIcon,
-  DocumentDuplicateIcon,
-  ExclamationCircleIcon,
-  PaperClipIcon,
-  PencilSquareIcon,
-  ShareIcon,
-  SpeakerWaveIcon,
-  SpeakerXMarkIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline';
+  Atom,
+  Brain,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Gauge,
+  GitMerge,
+  Paperclip,
+  RefreshCw,
+  SquarePen,
+  Trash2,
+  Volume2,
+  VolumeX,
+} from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useAppContext } from '../context/app';
@@ -223,7 +224,7 @@ export default function ChatMessage({
                 className="btn btn-ghost w-6 h-8 p-0"
                 onClick={() => prevSibling && onChangeSibling(prevSibling)}
                 disabled={!prevSibling}
-                icon={ChevronLeftIcon}
+                icon={ChevronLeft}
                 t={t}
                 titleKey="chatScreen.titles.previous"
                 ariaLabelKey="chatScreen.ariaLabels.switchToPrevious"
@@ -236,7 +237,7 @@ export default function ChatMessage({
                 className="btn btn-ghost w-6 h-8 p-0"
                 onClick={() => nextSibling && onChangeSibling(nextSibling)}
                 disabled={!nextSibling}
-                icon={ChevronRightIcon}
+                icon={ChevronRight}
                 t={t}
                 titleKey="chatScreen.titles.next"
                 ariaLabelKey="chatScreen.ariaLabels.switchToNext"
@@ -257,7 +258,7 @@ export default function ChatMessage({
               title={t('chatScreen.titles.regenerate')}
               aria-label={t('chatScreen.ariaLabels.regenerateResponse')}
             >
-              <ArrowPathIcon className="h-4 w-4" />
+              <RefreshCw className="h-4 w-4" />
             </button>
           )}
 
@@ -269,7 +270,7 @@ export default function ChatMessage({
               aria-label={t('chatScreen.ariaLabels.showPerformanceMetric')}
             >
               <div className="dropdown dropdown-hover dropdown-top">
-                <ExclamationCircleIcon className="h-4 w-4" />
+                <Gauge className="h-4 w-4" />
 
                 <div
                   tabIndex={0}
@@ -300,7 +301,7 @@ export default function ChatMessage({
             className="btn btn-ghost w-8 h-8 p-0"
             onClick={() => setIsEditing(msg.content !== null)}
             disabled={!msg.content}
-            icon={PencilSquareIcon}
+            icon={SquarePen}
             t={t}
             titleKey="chatScreen.titles.edit"
             ariaLabelKey="chatScreen.ariaLabels.editMessage"
@@ -310,7 +311,7 @@ export default function ChatMessage({
           <IntlIconButton
             className="btn btn-ghost w-8 h-8 p-0"
             onClick={handleCopy}
-            icon={DocumentDuplicateIcon}
+            icon={Copy}
             t={t}
             titleKey="chatScreen.titles.copy"
             ariaLabelKey="chatScreen.ariaLabels.copyContent"
@@ -333,7 +334,7 @@ export default function ChatMessage({
               }
             }}
             disabled={!msg.content}
-            icon={TrashIcon}
+            icon={Trash2}
             t={t}
             titleKey="chatScreen.titles.delete"
             ariaLabelKey="chatScreen.ariaLabels.deleteMessage"
@@ -347,7 +348,7 @@ export default function ChatMessage({
             t={t}
             titleKey="chatScreen.titles.branchChat"
             ariaLabelKey="chatScreen.ariaLabels.branchChatAfterMessage"
-            icon={ShareIcon}
+            icon={GitMerge}
           />
         </div>
       )}
@@ -396,7 +397,7 @@ function EditMessage({
               tabIndex={0}
               role="button"
             >
-              <PaperClipIcon className="h-5 w-5" />
+              <Paperclip className="h-5 w-5" />
             </label>
             <div className="grow" />
           </>
@@ -467,13 +468,13 @@ function ThoughtProcess({
         <div className="btn border-0 rounded-xl">
           {isThinking && (
             <>
-              <CubeTransparentIcon className="h-6 w-6 mr-1 p-0 animate-spin" />
+              <Atom className="h-6 w-6 mr-1 p-0 animate-spin" />
               <Trans i18nKey="chatScreen.labels.thinking" />
             </>
           )}
           {!isThinking && (
             <>
-              <CubeTransparentIcon className="h-6 w-6 mr-1 p-0" />
+              <Brain className="h-6 w-6 mr-1 p-0" />
               <Trans i18nKey="chatScreen.labels.thoughts" />
             </>
           )}
@@ -524,7 +525,7 @@ const PlayButton = ({
               t={t}
               titleKey="chatScreen.titles.play"
               ariaLabelKey="chatScreen.ariaLabels.playMessage"
-              icon={SpeakerWaveIcon}
+              icon={Volume2}
             />
           )}
           {isPlaying && (
@@ -535,7 +536,7 @@ const PlayButton = ({
               t={t}
               titleKey="chatScreen.titles.stop"
               ariaLabelKey="chatScreen.ariaLabels.stopMessage"
-              icon={SpeakerXMarkIcon}
+              icon={VolumeX}
             />
           )}
         </Fragment>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,4 @@
-import {
-  Bars3Icon,
-  Cog8ToothIcon,
-  PencilSquareIcon,
-} from '@heroicons/react/24/outline';
+import { Cog, Menu, SquarePen } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -44,7 +40,7 @@ export default function Header() {
       <section className="flex flex-row items-center xl:hidden">
         {/* open sidebar button */}
         <label htmlFor="toggle-drawer" className="btn btn-ghost w-8 h-8 p-0">
-          <Bars3Icon className="h-5 w-5" />
+          <Menu className="h-5 w-5" />
         </label>
 
         {/* spacer */}
@@ -68,7 +64,7 @@ export default function Header() {
           title={t('header.buttons.newConv')}
           aria-label={t('header.ariaLabels.newConv')}
         >
-          <PencilSquareIcon className="w-5 h-5" />
+          <SquarePen className="w-5 h-5" />
         </button>
       </section>
 
@@ -127,7 +123,7 @@ export default function Header() {
               onClick={() => navigate('/settings')}
             >
               {/* settings button */}
-              <Cog8ToothIcon className="w-5 h-5" />
+              <Cog className="w-5 h-5" />
             </button>
           </div>
         </section>

--- a/src/components/MarkdownDisplay.tsx
+++ b/src/components/MarkdownDisplay.tsx
@@ -1,6 +1,6 @@
-import { DocumentDuplicateIcon, PlayIcon } from '@heroicons/react/24/outline';
 import 'katex/dist/katex.min.css';
 import { all as languages } from 'lowlight';
+import { Copy, Play } from 'lucide-react';
 import React, { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Markdown, { ExtraProps } from 'react-markdown';
@@ -130,7 +130,7 @@ const CustomPre: React.ElementType<
               t={t}
               titleKey="chatScreen.titles.run"
               ariaLabelKey="chatScreen.ariaLabels.runCode"
-              icon={PlayIcon}
+              icon={Play}
               onClick={handleRun}
             />
           )}
@@ -139,7 +139,7 @@ const CustomPre: React.ElementType<
             t={t}
             titleKey="chatScreen.titles.copy"
             ariaLabelKey="chatScreen.ariaLabels.copyContent"
-            icon={DocumentDuplicateIcon}
+            icon={Copy}
             onClick={handleCopy}
           />
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 import {
-  ArrowDownTrayIcon,
-  EllipsisVerticalIcon,
-  PencilIcon,
-  PencilSquareIcon,
-  TrashIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline';
+  Download,
+  MoreVertical,
+  Pencil,
+  SquarePen,
+  Trash,
+  X,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
@@ -71,7 +71,7 @@ export default function Sidebar() {
               role="button"
               tabIndex={0}
             >
-              <XMarkIcon className="w-5 h-5" />
+              <X className="w-5 h-5" />
             </label>
 
             <label
@@ -90,7 +90,7 @@ export default function Sidebar() {
               title={t('header.buttons.newConv')}
               aria-label={t('header.ariaLabels.newConv')}
             >
-              <PencilSquareIcon className="w-5 h-5" />
+              <SquarePen className="w-5 h-5" />
             </button>
           </div>
 
@@ -237,7 +237,7 @@ function ConversationItem({
           title={t('sidebar.buttons.more')}
           aria-label={t('sidebar.ariaLabels.more')}
         >
-          <EllipsisVerticalIcon className="w-5 h-5" />
+          <MoreVertical className="w-5 h-5" />
         </button>
         {/* dropdown menu */}
         <ul
@@ -252,7 +252,7 @@ function ConversationItem({
               title={t('sidebar.buttons.rename')}
               aria-label={t('sidebar.ariaLabels.rename')}
             >
-              <PencilIcon className="w-4 h-4" />
+              <Pencil className="w-4 h-4" />
               <Trans i18nKey="sidebar.buttons.rename" />
             </button>
           </li>
@@ -262,7 +262,7 @@ function ConversationItem({
               title={t('sidebar.buttons.download')}
               aria-label={t('sidebar.ariaLabels.download')}
             >
-              <ArrowDownTrayIcon className="w-4 h-4" />
+              <Download className="w-4 h-4" />
               <Trans i18nKey="sidebar.buttons.download" />
             </button>
           </li>
@@ -277,7 +277,7 @@ function ConversationItem({
               title={t('sidebar.buttons.delete')}
               aria-label={t('sidebar.ariaLabels.delete')}
             >
-              <TrashIcon className="w-4 h-4" />
+              <Trash className="w-4 h-4" />
               <Trans i18nKey="sidebar.buttons.delete" />
             </button>
           </li>

--- a/src/components/common.tsx
+++ b/src/components/common.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from '@heroicons/react/24/outline';
+import { ChevronDown } from 'lucide-react';
 import {
   ButtonHTMLAttributes,
   FC,
@@ -243,9 +243,7 @@ export function Dropdown<T extends DropdownOption>({
             aria-haspopup="listbox"
           >
             {currentValue}
-            {!hideChevron && (
-              <ChevronDownIcon className="inline h-5 w-5 ml-1" />
-            )}
+            {!hideChevron && <ChevronDown className="inline h-5 w-5 ml-1" />}
           </summary>
 
           {/* dropdown content */}

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,6 +7,10 @@
 /* Highlight.js */
 @import url(highlight.js.scss);
 
+.lucide {
+  stroke-width: 1.5px;
+}
+
 html {
   scrollbar-gutter: auto;
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,31 +1,31 @@
 import {
-  ArrowDownTrayIcon,
-  ArrowPathIcon,
-  ArrowUpTrayIcon,
-  BeakerIcon,
-  BookmarkIcon,
-  ChatBubbleLeftEllipsisIcon,
-  ChatBubbleLeftRightIcon,
-  ChatBubbleOvalLeftEllipsisIcon,
-  CircleStackIcon,
-  CloudArrowUpIcon,
-  Cog6ToothIcon,
-  CogIcon,
-  CpuChipIcon,
-  EllipsisVerticalIcon,
-  EyeIcon,
-  FunnelIcon,
-  HandRaisedIcon,
-  PencilIcon,
-  PlayCircleIcon,
-  RocketLaunchIcon,
-  SignalIcon,
-  SpeakerWaveIcon,
-  SpeakerXMarkIcon,
-  SquaresPlusIcon,
-  TrashIcon,
-  TvIcon,
-} from '@heroicons/react/24/outline';
+  AudioLines,
+  Bookmark,
+  Brain,
+  CirclePlay,
+  CloudDownload,
+  CloudUpload,
+  Cog,
+  Cpu,
+  Database,
+  EllipsisVertical,
+  Eye,
+  FlaskConical,
+  Funnel,
+  Grid2X2Plus,
+  Hand,
+  MessageCircleMore,
+  MessagesSquare,
+  Monitor,
+  Pencil,
+  RefreshCw,
+  Rocket,
+  Settings as SettingsIcon,
+  Speech,
+  Trash,
+  Volume2,
+  VolumeX,
+} from 'lucide-react';
 import React, {
   FC,
   forwardRef,
@@ -206,7 +206,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <Cog6ToothIcon className={ICON_CLASSNAME} />
+        <SettingsIcon className={ICON_CLASSNAME} />
         {t('settings.tabs.general')}
       </>
     ),
@@ -252,14 +252,14 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <TvIcon className={ICON_CLASSNAME} />
+        <Monitor className={ICON_CLASSNAME} />
         {t('settings.tabs.ui')}
       </>
     ),
     fields: [
       toSection(
         t('settings.sections.userInterface'),
-        <TvIcon className={ICON_CLASSNAME} />
+        <Monitor className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.SHORT_INPUT, 'initials'),
       {
@@ -279,7 +279,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <SignalIcon className={ICON_CLASSNAME} />
+        <AudioLines className={ICON_CLASSNAME} />
         {t('settings.tabs.voice')}
       </>
     ),
@@ -287,7 +287,7 @@ const getSettingTabsConfiguration = (
       /* Text to Speech */
       toSection(
         t('settings.sections.textToSpeech'),
-        <SpeakerWaveIcon className={ICON_CLASSNAME} />
+        <Speech className={ICON_CLASSNAME} />
       ),
       toDropdown(
         'ttsVoice',
@@ -348,8 +348,8 @@ const getSettingTabsConfiguration = (
                 title="Play test message"
                 aria-label="Play test message"
               >
-                {!isPlaying && <SpeakerWaveIcon className={ICON_CLASSNAME} />}
-                {isPlaying && <SpeakerXMarkIcon className={ICON_CLASSNAME} />}
+                {!isPlaying && <Volume2 className={ICON_CLASSNAME} />}
+                {isPlaying && <VolumeX className={ICON_CLASSNAME} />}
                 {t('settings.textToSpeech.check.label')}
               </button>
             )}
@@ -363,14 +363,14 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <ChatBubbleLeftRightIcon className={ICON_CLASSNAME} />
+        <MessagesSquare className={ICON_CLASSNAME} />
         {t('settings.tabs.conversations')}
       </>
     ),
     fields: [
       toSection(
         t('settings.sections.chat'),
-        <ChatBubbleLeftEllipsisIcon className={ICON_CLASSNAME} />
+        <MessageCircleMore className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.SHORT_INPUT, 'pasteLongTextToFileLen'),
       toInput(SettingInputType.CHECKBOX, 'pdfAsImage'),
@@ -379,7 +379,7 @@ const getSettingTabsConfiguration = (
       DELIMITER,
       toSection(
         t('settings.sections.performance'),
-        <RocketLaunchIcon className={ICON_CLASSNAME} />
+        <Rocket className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.CHECKBOX, 'showTokensPerSecond'),
 
@@ -387,7 +387,7 @@ const getSettingTabsConfiguration = (
       DELIMITER,
       toSection(
         t('settings.sections.reasoning'),
-        <ChatBubbleOvalLeftEllipsisIcon className={ICON_CLASSNAME} />
+        <Brain className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.CHECKBOX, 'showThoughtInProgress'),
       toInput(SettingInputType.CHECKBOX, 'excludeThoughtOnReq'),
@@ -398,7 +398,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <BookmarkIcon className={ICON_CLASSNAME} />
+        <Bookmark className={ICON_CLASSNAME} />
         {t('settings.tabs.presets')}
       </>
     ),
@@ -415,7 +415,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <CircleStackIcon className={ICON_CLASSNAME} />
+        <Database className={ICON_CLASSNAME} />
         {t('settings.tabs.importExport')}
       </>
     ),
@@ -432,7 +432,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <SquaresPlusIcon className={ICON_CLASSNAME} />
+        <Grid2X2Plus className={ICON_CLASSNAME} />
         {t('settings.tabs.advanced')}
       </>
     ),
@@ -440,7 +440,7 @@ const getSettingTabsConfiguration = (
       /* Generation */
       toSection(
         t('settings.sections.generation'),
-        <CogIcon className={ICON_CLASSNAME} />
+        <Cog className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.CHECKBOX, 'overrideGenerationOptions'),
       ...['temperature', 'top_k', 'top_p', 'min_p', 'max_tokens'].map((key) =>
@@ -455,7 +455,7 @@ const getSettingTabsConfiguration = (
       DELIMITER,
       toSection(
         t('settings.sections.samplers'),
-        <FunnelIcon className={ICON_CLASSNAME} />
+        <Funnel className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.CHECKBOX, 'overrideSamplersOptions'),
       ...[
@@ -477,7 +477,7 @@ const getSettingTabsConfiguration = (
       DELIMITER,
       toSection(
         t('settings.sections.penalties'),
-        <HandRaisedIcon className={ICON_CLASSNAME} />
+        <Hand className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.CHECKBOX, 'overridePenaltyOptions'),
       ...[
@@ -501,7 +501,7 @@ const getSettingTabsConfiguration = (
       DELIMITER,
       toSection(
         t('settings.sections.custom'),
-        <CpuChipIcon className={ICON_CLASSNAME} />
+        <Cpu className={ICON_CLASSNAME} />
       ),
       toInput(SettingInputType.LONG_INPUT, 'custom'),
     ],
@@ -511,7 +511,7 @@ const getSettingTabsConfiguration = (
   {
     title: (
       <>
-        <BeakerIcon className={ICON_CLASSNAME} />
+        <FlaskConical className={ICON_CLASSNAME} />
         <Trans i18nKey="settings.sections.experimental" />
       </>
     ),
@@ -758,7 +758,7 @@ export default function Settings() {
                   )
                 }
               >
-                <ArrowPathIcon className={ICON_CLASSNAME} />
+                <RefreshCw className={ICON_CLASSNAME} />
                 <Trans i18nKey="settings.actionButtons.fetchModels" />
               </button>
             );
@@ -1347,7 +1347,7 @@ const PresetManager: FC<{
         title={t('settings.presetManager.buttons.save')}
         aria-label={t('settings.presetManager.ariaLabels.save')}
       >
-        <CloudArrowUpIcon className="w-5 h-5" />
+        <CloudUpload className="w-5 h-5" />
         <Trans i18nKey="settings.presetManager.buttons.save" />
       </button>
 
@@ -1384,7 +1384,7 @@ const PresetManager: FC<{
                       title={t('settings.presetManager.buttons.load')}
                       aria-label={t('settings.presetManager.ariaLabels.load')}
                     >
-                      <PlayCircleIcon className="w-5 h-5" />
+                      <CirclePlay className="w-5 h-5" />
                     </button>
 
                     {/* dropdown */}
@@ -1394,7 +1394,7 @@ const PresetManager: FC<{
                         title={t('settings.presetManager.buttons.more')}
                         aria-label={t('settings.presetManager.ariaLabels.more')}
                       >
-                        <EllipsisVerticalIcon className="w-5 h-5" />
+                        <EllipsisVertical className="w-5 h-5" />
                       </button>
 
                       {/* dropdown menu */}
@@ -1413,7 +1413,7 @@ const PresetManager: FC<{
                               'settings.presetManager.ariaLabels.rename'
                             )}
                           >
-                            <PencilIcon className={ICON_CLASSNAME} />
+                            <Pencil className={ICON_CLASSNAME} />
                             {t('settings.presetManager.buttons.rename')}
                           </button>
                         </li>
@@ -1426,7 +1426,7 @@ const PresetManager: FC<{
                               'settings.presetManager.ariaLabels.delete'
                             )}
                           >
-                            <TrashIcon className={ICON_CLASSNAME} />
+                            <Trash className={ICON_CLASSNAME} />
                             {t('settings.presetManager.buttons.delete')}
                           </button>
                         </li>
@@ -1485,13 +1485,13 @@ const ImportExportComponent: React.FC<{ onClose: () => void }> = ({
   return (
     <>
       <SettingsSectionLabel>
-        <ChatBubbleOvalLeftEllipsisIcon className={ICON_CLASSNAME} />
+        <MessageCircleMore className={ICON_CLASSNAME} />
         {t('settings.importExport.chatsSectionTitle')}
       </SettingsSectionLabel>
 
       <div className="grid grid-cols-[repeat(2,max-content)] gap-2">
         <button className="btn" onClick={onExport}>
-          <ArrowDownTrayIcon className={ICON_CLASSNAME} />
+          <CloudDownload className={ICON_CLASSNAME} />
           {t('settings.importExport.exportBtnLabel')}
         </button>
 
@@ -1509,7 +1509,7 @@ const ImportExportComponent: React.FC<{ onClose: () => void }> = ({
           tabIndex={0}
           role="button"
         >
-          <ArrowUpTrayIcon className={ICON_CLASSNAME} />
+          <CloudUpload className={ICON_CLASSNAME} />
           {t('settings.importExport.importBtnLabel')}
         </label>
       </div>
@@ -1517,7 +1517,7 @@ const ImportExportComponent: React.FC<{ onClose: () => void }> = ({
       <DelimeterComponent />
 
       <SettingsSectionLabel>
-        <EyeIcon className={ICON_CLASSNAME} />
+        <Eye className={ICON_CLASSNAME} />
         {t('settings.importExport.technicalDemoSectionTitle')}
       </SettingsSectionLabel>
 


### PR DESCRIPTION
- Remove @heroicons/react dependency and add lucide-react
- Update package.json and package-lock.json
- Replace heroicons imports across components (CanvasPyInterpreter, ChatInput, ChatInputExtraContextItem, ChatMessage, Header, MarkdownDisplay, Sidebar, common, Settings, etc.) with lucide-react equivalents
- Update icon usage to lucide-react components
- Add .lucide CSS rule for consistent stroke width