### PR TITLE
refactor(common): add downloadAsFile helper and streamline download logic

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import { useModals } from '../context/modal';
 import StorageUtils from '../database';
 import { Conversation } from '../types';
 import { classNames } from '../utils';
+import { downloadAsFile } from './common';
 
 export default function Sidebar() {
   const navigate = useNavigate();
@@ -144,19 +145,12 @@ export default function Sidebar() {
                         toast.error(t('sidebar.errors.downloadOnGenerate'));
                         return;
                       }
-                      const data = await StorageUtils.exportDB(conv.id);
-                      const conversationJson = JSON.stringify(data, null, 2);
-                      const blob = new Blob([conversationJson], {
-                        type: 'application/json',
-                      });
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement('a');
-                      a.href = url;
-                      a.download = `conversation_${conv.id}.json`;
-                      document.body.appendChild(a);
-                      a.click();
-                      document.body.removeChild(a);
-                      URL.revokeObjectURL(url);
+                      return StorageUtils.exportDB(conv.id).then((data) =>
+                        downloadAsFile(
+                          [JSON.stringify(data, null, 2)],
+                          `conversation_${conv.id}.json`
+                        )
+                      );
                     }}
                     onRename={async () => {
                       if (isGenerating(conv.id)) {

--- a/src/components/common.tsx
+++ b/src/components/common.tsx
@@ -60,6 +60,20 @@ export const OpenInNewTab = ({
   </a>
 );
 
+export const downloadAsFile = (blobParts: BlobPart[], fileName: string) => {
+  const blob = new Blob(blobParts, {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
 /**
  * @deprecated Use `title` and `aria-label` props in button directly as utiliy classes.
  *

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -40,7 +40,7 @@ import {
   LuVolumeX,
 } from 'react-icons/lu';
 import { useNavigate } from 'react-router';
-import { Dropdown } from '../components/common';
+import { downloadAsFile, Dropdown } from '../components/common';
 import TextToSpeech, {
   getSpeechSynthesisVoiceByName,
   getSpeechSynthesisVoices,
@@ -1449,19 +1449,9 @@ const ImportExportComponent: React.FC<{ onClose: () => void }> = ({
   const { importDB, exportDB } = useAppContext();
 
   const onExport = async () => {
-    const data = await exportDB();
-    const conversationJson = JSON.stringify(data, null, 2);
-    const blob = new Blob([conversationJson], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `database.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    return exportDB().then((data) =>
+      downloadAsFile([JSON.stringify(data, null, 2)], 'llama-ui-database.json')
+    );
   };
 
   const onImport = async (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
- Introduced `downloadAsFile` in `components/common.tsx` to encapsulate blob creation and download.
- Updated `Sidebar.tsx` and `Settings.tsx` to use this helper instead of inline download code.
- Removes duplicated download logic and simplifies maintenance.