### PR TITLE
fix(provider): add Google provider and extend BaseOpenAIProvider

### DIFF
--- a/src/api/providers/GoogleProvider.ts
+++ b/src/api/providers/GoogleProvider.ts
@@ -1,0 +1,83 @@
+import { InferenceApiModel } from '../../types';
+import { BaseOpenAIProvider } from './BaseOpenAIProvider';
+
+/**
+ * Represents a Google model metadata structure as returned by the API.
+ *
+ * @interface GoogleModel
+ * @property {string} id - Unique identifier for the model.
+ * @property {string} object - Object type, typically "model".
+ * @property {string} owned_by - Owner of the model (e.g., organization or user).
+ * @property {string} display_name - Human-readable name of the model for UI display.
+ */
+interface GoogleModel {
+  id: string;
+  object: string;
+  owned_by: string;
+  display_name: string;
+}
+
+/**
+ * GoogleProvider extends BaseOpenAIProvider to handle Google's model API responses.
+ *
+ * This class adapts Google's model response format to the standard InferenceApiModel interface
+ * used by the application. It implements a 15-minute cache expiration policy.
+ *
+ * @example
+ * const provider = GoogleProvider.new('https://api.google.com', 'your-api-key');
+ * const models = await provider.getModels();
+ *
+ * @class GoogleProvider
+ * @extends BaseOpenAIProvider
+ */
+export class GoogleProvider extends BaseOpenAIProvider {
+  /**
+   * Creates a new instance of GoogleProvider with optional base URL and API key.
+   *
+   * This is a static factory method that provides a convenient way to construct
+   * a GoogleProvider instance without using the constructor directly.
+   *
+   * @static
+   * @param {string} [baseUrl] - Optional base URL for the Google API endpoint.
+   *                             Defaults to the parent class's default if not provided.
+   * @param {string} [apiKey=''] - API key for authentication. Required for actual API calls.
+   * @returns {GoogleProvider} A new instance of GoogleProvider.
+   *
+   * @example
+   * const provider = GoogleProvider.new(); // Uses default base URL and empty key
+   * const provider = GoogleProvider.new('https://api.google.com/v1', 'my-key');
+   */
+  static new(baseUrl?: string, apiKey: string = ''): GoogleProvider {
+    return new GoogleProvider(baseUrl, apiKey);
+  }
+
+  /** @inheritdoc */
+  protected isExpired(): boolean {
+    return Date.now() - this.lastUpdated > 15 * 60 * 1000;
+  }
+
+  /** @inheritdoc */
+  protected isAllowCustomOptions(): boolean {
+    return false;
+  }
+
+  /** @inheritdoc */
+  protected isSupportCache(): boolean {
+    return false;
+  }
+
+  /** @inheritdoc */
+  protected isSupportTimings(): boolean {
+    return false;
+  }
+
+  /** @inheritdoc */
+  protected jsonToModel(m: unknown): InferenceApiModel {
+    const model = m as GoogleModel;
+
+    return {
+      id: model.id,
+      name: model.display_name,
+    };
+  }
+}

--- a/src/api/providers/LlamaCppProvider.ts
+++ b/src/api/providers/LlamaCppProvider.ts
@@ -93,16 +93,19 @@ export class LlamaCppProvider extends BaseOpenAIProvider {
     return new LlamaCppProvider(baseUrl, apiKey);
   }
 
+  /** @inheritdoc */
   async getModels(): Promise<InferenceApiModel[]> {
     await this.getServerProps();
 
     return super.getModels();
   }
 
+  /** @inheritdoc */
   protected isExpired() {
     return true;
   }
 
+  /** @inheritdoc */
   protected jsonToModel(m: unknown): InferenceApiModel {
     const model = m as InferenceApiModel;
     const modalities: Modality[] = ['text'];

--- a/src/api/providers/OpenRouterProvider.ts
+++ b/src/api/providers/OpenRouterProvider.ts
@@ -64,14 +64,7 @@ export class OpenRouterProvider extends BaseOpenAIProvider {
     return new OpenRouterProvider(baseUrl, apiKey);
   }
 
-  /**
-   * Determines if the provider's model cache has expired.
-   *
-   * OpenRouter models are cached for 15 minutes to reduce API calls.
-   * This method checks whether the last update time exceeds this threshold.
-   *
-   * @returns `true` if the cache has expired (>15 minutes since last update), otherwise `false`
-   */
+  /** @inheritdoc */
   protected isExpired(): boolean {
     return Date.now() - this.lastUpdated > 15 * 60 * 1000;
   }

--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -1,5 +1,6 @@
 import { InferenceProvider } from '../../types';
 import { BaseOpenAIProvider } from './BaseOpenAIProvider';
+import { GoogleProvider } from './GoogleProvider';
 import { LlamaCppProvider } from './LlamaCppProvider';
 import { OpenRouterProvider } from './OpenRouterProvider';
 
@@ -26,6 +27,9 @@ export function getInferenceProvider(
       break;
     case 'open-router':
       provider = OpenRouterProvider.new(baseUrl, apiKey);
+      break;
+    case 'google':
+      provider = GoogleProvider.new(baseUrl, apiKey);
       break;
     default:
       provider = BaseOpenAIProvider.new(baseUrl, apiKey);

--- a/src/config/inference-providers.json
+++ b/src/config/inference-providers.json
@@ -49,7 +49,7 @@
     "isKeyRequired": true
   },
   "google": {
-    "baseUrl": "https://generativelanguage.googleapis.com",
+    "baseUrl": "https://generativelanguage.googleapis.com/v1beta/openai",
     "name": "Google",
     "icon": "assets/providers/google.svg",
     "allowCustomBaseUrl": false,


### PR DESCRIPTION
- Introduce GoogleProvider with no cache/timing support.
- Refactor BaseOpenAIProvider:
  - Add `isAllowCustomOptions`, `isSupportCache`, `isSupportTimings`.
  - Conditionally add `cache_prompt` and `timings_per_token` params.
- Update `inference-providers.json` to set Google baseUrl to `https://generativelanguage.googleapis.com/v1beta/openai`.