### PR TITLE
fix(api): update provider cache key to include base URL

### DIFF
--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -14,10 +14,11 @@ export function getInferenceProvider(
 ): InferenceProvider {
   if (!baseUrl) throw new Error(`Base URL is not specified`);
 
-  if (PROVIDER_CACHE.has(baseUrl)) {
-    const provider = PROVIDER_CACHE.get(baseUrl)!;
+  const cacheKey = `${key}-${baseUrl}`;
+  if (PROVIDER_CACHE.has(cacheKey)) {
+    const provider = PROVIDER_CACHE.get(cacheKey)!;
     if (provider.getApiKey() === apiKey) {
-      return PROVIDER_CACHE.get(baseUrl)!;
+      return PROVIDER_CACHE.get(cacheKey)!;
     }
   }
 


### PR DESCRIPTION
- Use combined cache key of provider key and base URL to ensure proper cache invalidation when API keys change
- Prevents stale provider instances from being returned when the same base URL is used with different API keys