### PR TITLE
ci: update GitHub Pages deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,15 +6,22 @@ on:
   #      - '**'
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: 'pages'
+      cancel-in-progress: false
 
     steps:
       - name: Skip for non-tagged refs
@@ -44,8 +51,14 @@ jobs:
       - name: Set custom domain
         run: echo "llama-ui.js.org" >> ./dist/CNAME
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ on:
           - minor
           - patch
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -188,6 +184,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: release
 
@@ -195,7 +194,8 @@ jobs:
       contents: write
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: 'pages'
+      cancel-in-progress: false
 
     steps:
       - name: Checkout specific tag
@@ -225,13 +225,22 @@ jobs:
       - name: Set custom domain
         run: echo "llama-ui.js.org" >> ./dist/CNAME
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   docker:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     runs-on: ubuntu-latest
     needs: release
 


### PR DESCRIPTION
- Add proper permissions for GitHub Pages deployment
- Configure environment for GitHub Pages in both deploy and release workflows
- Replace peaceiris/actions-gh-pages with official GitHub Pages actions (configure-pages, upload-pages-artifact, deploy-pages)
- Update concurrency groups to 'pages' with cancel-in-progress set to false
- Move environment configuration to deploy job in release workflow
- Add REGISTRY and IMAGE_NAME environment variables back to docker job in release workflow