### PR TITLE
refactor(api): replace SSE processing with native stream processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.30.2",
       "license": "MIT",
       "dependencies": {
-        "@sec-ant/readable-stream": "^0.6.0",
         "dexie": "^4.0.11",
         "highlight.js": "^11.10.0",
         "i18next": "^25.5.2",
@@ -28,8 +27,7 @@
         "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
-        "remark-math": "^6.0.0",
-        "textlinestream": "^1.1.1"
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -2972,12 +2970,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.6.0.tgz",
-      "integrity": "sha512-uiBh8DrB5FN35gP6/o8JEhEQ7/ci1jUsOZO/VMUjyvTpjtV54VstOXVj1TvTj/wsT23pfX6butxxh3qufsW3+g==",
-      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -9972,12 +9964,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/textlinestream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/textlinestream/-/textlinestream-1.1.1.tgz",
-      "integrity": "sha512-iBHbi7BQxrFmwZUQJsT0SjNzlLLsXhvW/kg7EyOMVMBIrlnj/qYofwo1LVLZi+3GbUEo96Iu2eqToI2+lZoAEQ==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "preview": "npm run build && vite preview"
   },
   "dependencies": {
-    "@sec-ant/readable-stream": "^0.6.0",
     "dexie": "^4.0.11",
     "highlight.js": "^11.10.0",
     "i18next": "^25.5.2",
@@ -36,8 +35,7 @@
     "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",
-    "remark-math": "^6.0.0",
-    "textlinestream": "^1.1.1"
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/api/providers/BaseOpenAIProvider.ts
+++ b/src/api/providers/BaseOpenAIProvider.ts
@@ -5,9 +5,10 @@ import {
   InferenceApiModel,
   LLMProvider,
   ModelProvider,
+  SSEChatCompletionMessage,
 } from '../../types';
 import { normalizeUrl } from '../../utils';
-import { getSSEStreamAsync, noResponse } from '../utils';
+import { noResponse, processSSEStream } from '../utils';
 
 /**
  * Base implementation for OpenAI-compatible API providers.
@@ -171,7 +172,7 @@ export class BaseOpenAIProvider
    * }
    * ```
    *
-   * @see {@link getSSEStreamAsync}
+   * @see {@link processSSEStream}
    * @see {@link getDefaultChatParams}
    * @see {@link isAllowCustomOptions}
    */
@@ -216,7 +217,7 @@ export class BaseOpenAIProvider
     }
 
     await this.isErrorResponse(fetchResponse);
-    return getSSEStreamAsync(fetchResponse);
+    return processSSEStream<SSEChatCompletionMessage>(fetchResponse);
   }
 
   /**

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -75,9 +75,13 @@ export default memo(function ChatMessage({
         ? {
             ...msg.timings,
             prompt_per_second:
-              (msg.timings.prompt_n / msg.timings.prompt_ms) * 1000,
+              !msg.timings.prompt_n || !msg.timings.prompt_ms
+                ? undefined
+                : (msg.timings.prompt_n / msg.timings.prompt_ms) * 1000,
             predicted_per_second:
-              (msg.timings.predicted_n / msg.timings.predicted_ms) * 1000,
+              !msg.timings.predicted_n || !msg.timings.predicted_ms
+                ? undefined
+                : (msg.timings.predicted_n / msg.timings.predicted_ms) * 1000,
           }
         : null,
     [msg.timings]
@@ -256,7 +260,7 @@ export default memo(function ChatMessage({
           )}
 
           {/* render timings if enabled */}
-          {isAssistant && timings && showTokensPerSecond && (
+          {timings && showTokensPerSecond && (
             <button
               className="btn btn-ghost w-8 h-8 p-0"
               title={t('chatScreen.titles.performance')}
@@ -269,21 +273,43 @@ export default memo(function ChatMessage({
                   tabIndex={0}
                   className="dropdown-content rounded-box bg-base-100 z-10 w-48 px-4 py-2 shadow mt-4 text-sm text-left"
                 >
-                  <b>Prompt Processing</b>
-                  <ul className="list-inside list-disc">
-                    <li>Tokens: {timings.prompt_n.toFixed(0)}</li>
-                    <li>Time: {timings.prompt_ms.toFixed(0)} ms</li>
-                    <li>Speed: {timings.prompt_per_second.toFixed(1)} t/s</li>
-                  </ul>
-                  <br />
-                  <b>Generation</b>
-                  <ul className="list-inside list-disc">
-                    <li>Tokens: {timings.predicted_n.toFixed(0)}</li>
-                    <li>Time: {timings.predicted_ms.toFixed(0)} ms</li>
-                    <li>
-                      Speed: {timings.predicted_per_second.toFixed(1)} t/s
-                    </li>
-                  </ul>
+                  {(timings.prompt_n || timings.prompt_ms) && (
+                    <>
+                      <b>Prompt Processing</b>
+                      <ul className="list-inside list-disc">
+                        {timings.prompt_n && (
+                          <li>Tokens: {timings.prompt_n.toFixed(0)}</li>
+                        )}
+                        {timings.prompt_ms && (
+                          <li>Time: {timings.prompt_ms.toFixed(0)} ms</li>
+                        )}
+                        {timings.prompt_per_second && (
+                          <li>
+                            Speed: {timings.prompt_per_second.toFixed(1)} t/s
+                          </li>
+                        )}
+                      </ul>
+                      <br />
+                    </>
+                  )}
+                  {(timings.predicted_n || timings.predicted_ms) && (
+                    <>
+                      <b>Generation</b>
+                      <ul className="list-inside list-disc">
+                        {timings.predicted_n && (
+                          <li>Tokens: {timings.predicted_n.toFixed(0)}</li>
+                        )}
+                        {timings.predicted_ms && (
+                          <li>Time: {timings.predicted_ms.toFixed(0)} ms</li>
+                        )}
+                        {timings.predicted_per_second && (
+                          <li>
+                            Speed: {timings.predicted_per_second.toFixed(1)} t/s
+                          </li>
+                        )}
+                      </ul>
+                    </>
+                  )}
                 </div>
               </div>
             </button>

--- a/src/context/chat.tsx
+++ b/src/context/chat.tsx
@@ -360,14 +360,17 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
             };
           }
 
-          const timings = chunk.timings;
-          if (timings) {
-            // only extract what's really needed, to save some space
+          if (chunk.timings) {
             pendingMsg.timings = {
-              prompt_n: timings.prompt_n,
-              prompt_ms: timings.prompt_ms,
-              predicted_n: timings.predicted_n,
-              predicted_ms: timings.predicted_ms,
+              prompt_n: chunk.timings.prompt_n,
+              prompt_ms: chunk.timings.prompt_ms,
+              predicted_n: chunk.timings.predicted_n,
+              predicted_ms: chunk.timings.predicted_ms,
+            };
+          } else if (chunk.usage) {
+            pendingMsg.timings = {
+              prompt_n: chunk.usage.prompt_tokens,
+              predicted_n: chunk.usage.completion_tokens,
             };
           }
           setPending(convId, pendingMsg);

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,8 +1,8 @@
 export interface TimingReport {
-  prompt_n: number;
-  prompt_ms: number;
-  predicted_n: number;
-  predicted_ms: number;
+  prompt_n?: number;
+  prompt_ms?: number;
+  predicted_n?: number;
+  predicted_ms?: number;
 }
 
 /**

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,24 +1,198 @@
 import { InferenceApiMessage, InferenceApiModel } from './inference';
 
+/**
+ * Represents generic data payload structure for Server-Sent Events (SSE).
+ * Used as a flexible container for arbitrary key-value pairs in SSE messages.
+ * @interface
+ */
+export interface SSEData {
+  [key: string]: unknown;
+}
+
+/**
+ * Represents a single Server-Sent Event (SSE) message with a defined type and value.
+ * This interface conforms to the SSE specification and is used to parse incoming events.
+ * @interface
+ * @property {('data' | 'error' | 'event' | 'id' | 'retry')} type - The type of SSE event.
+ * @property {string} value - The raw string value of the event payload.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+ */
+export interface SSEMessage {
+  type: 'data' | 'error' | 'event' | 'id' | 'retry';
+  value: string;
+}
+
+/**
+ * Represents a streamed chat completion message from an LLM provider using Server-Sent Events (SSE).
+ * This interface extends `SSEData` and includes standardized fields for chat completions.
+ * Supports both OpenRouter and llama.cpp formats via optional fields.
+ * @interface
+ * @extends {SSEData}
+ * @property {string} id - Unique identifier for this completion response.
+ * @property {string} model - The model name used for generation.
+ * @property {string} object - Object type, typically "chat.completion.chunk".
+ * @property {number} created - Unix timestamp when the completion was created.
+ * @property {Choice[]} [choices] - Array of response choices (delta updates).
+ * @property {Error} [error] - Error object if the stream encountered an error.
+ * @property {Timings} [timings] - Performance timings from llama.cpp backend.
+ * @property {Usage} [usage] - Token usage statistics from OpenRouter backend.
+ */
+export interface SSEChatCompletionMessage extends SSEData {
+  id: string;
+  model: string;
+  object: string;
+  created: number;
+  choices?: Choice[];
+  error?: Error;
+  timings?: Timings;
+  usage?: Usage;
+}
+
+/**
+ * Represents a single choice (response option) in a streaming chat completion.
+ * Typically one choice is returned per message in streaming mode.
+ * @interface
+ * @property {number} index - Zero-based index of this choice.
+ * @property {Delta} delta - Incremental update to the response content.
+ * @property {string} [finish_reason] - Reason the stream ended (e.g., "stop", "length", "error").
+ */
+interface Choice {
+  index: number;
+  delta: Delta;
+  finish_reason?: string;
+}
+
+/**
+ * Represents a partial update (delta) to a message in a streaming chat completion.
+ * Contains incremental text or metadata changes from the model.
+ * Supports both OpenRouter and llama.cpp-specific fields for reasoning traces.
+ * @interface
+ * @property {string} [role] - Role of the message sender (e.g., "assistant").
+ * @property {string} [content] - Incremental text content added to the response.
+ * @property {string} [reasoning] - (OpenRouter) Reasoning trace or chain-of-thought output.
+ * @property {string} [reasoning_content] - (llama.cpp) Alternative reasoning content field.
+ */
+interface Delta {
+  role?: string;
+  content?: string;
+  reasoning?: string;
+  reasoning_content?: string;
+}
+
+/**
+ * Performance timing metrics from the llama.cpp inference engine.
+ * Captures latency and throughput statistics for prompt processing and token generation.
+ * @interface
+ * @property {number} cache_n - Number of cached tokens.
+ * @property {number} prompt_n - Number of tokens in the prompt.
+ * @property {number} prompt_ms - Time in milliseconds to process the prompt.
+ * @property {number} prompt_per_token_ms - Average time per prompt token in milliseconds.
+ * @property {number} prompt_per_second - Tokens processed per second during prompt phase.
+ * @property {number} predicted_n - Number of tokens generated.
+ * @property {number} predicted_ms - Time in milliseconds to generate predicted tokens.
+ * @property {number} predicted_per_token_ms - Average time per generated token in milliseconds.
+ * @property {number} predicted_per_second - Tokens generated per second.
+ */
+interface Timings {
+  cache_n: number;
+  prompt_n: number;
+  prompt_ms: number;
+  prompt_per_token_ms: number;
+  prompt_per_second: number;
+  predicted_n: number;
+  predicted_ms: number;
+  predicted_per_token_ms: number;
+  predicted_per_second: number;
+}
+
+/**
+ * Token usage statistics from OpenRouter API.
+ * Reports token consumption for prompt and completion phases.
+ * @interface
+ * @property {number} prompt_tokens - Number of tokens in the input prompt.
+ * @property {number} completion_tokens - Number of tokens in the generated response.
+ * @property {number} total_tokens - Sum of prompt and completion tokens.
+ */
+interface Usage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+/**
+ * Interface defining the contract for an LLM provider configuration.
+ * Provides access to the base URL and API key required for authentication.
+ * @interface
+ * @method getBaseUrl - Returns the base API endpoint URL.
+ * @method getApiKey - Returns the API key for authentication, or undefined if not set.
+ */
 export interface LLMProvider {
+  /**
+   * Gets the base URL of the LLM API endpoint.
+   * @returns {string} The base URL (e.g., "https://api.openrouter.ai").
+   */
   getBaseUrl(): string;
+
+  /**
+   * Gets the API key used for authenticating requests.
+   * @returns {string | undefined} The API key, or undefined if not configured.
+   */
   getApiKey(): string | undefined;
 }
 
+/**
+ * Interface defining the contract for retrieving available models from an LLM provider.
+ * @interface
+ * @method getModels - Fetches the list of available models asynchronously.
+ * @returns {Promise<InferenceApiModel[]>} A promise resolving to an array of model definitions.
+ */
 export interface ModelProvider {
+  /**
+   * Retrieves the list of available models from the provider.
+   * @returns {Promise<InferenceApiModel[]>} A promise that resolves to an array of model definitions.
+   */
   getModels(): Promise<InferenceApiModel[]>;
 }
 
+/**
+ * Interface defining the contract for generating streaming chat completions.
+ * Supports abort signals and custom options for advanced control.
+ * @interface
+ * @method postChatCompletions - Sends a chat request and returns a streaming generator.
+ * @param {string} model - The model identifier to use (e.g., "openai/gpt-4").
+ * @param {readonly InferenceApiMessage[]} messages - The conversation history.
+ * @param {AbortSignal} abortSignal - Signal to cancel the request.
+ * @param {object} [customOptions] - Optional provider-specific configuration.
+ * @returns {Promise<AsyncGenerator<SSEChatCompletionMessage, void, undefined>>} A stream of SSE messages.
+ */
 export interface ChatCompletionProvider {
+  /**
+   * Sends a chat completion request and returns a streaming generator of SSE messages.
+   * The generator yields partial responses as they arrive from the server.
+   * @param {string} model - The model identifier to use for generation.
+   * @param {readonly InferenceApiMessage[]} messages - The conversation history as messages.
+   * @param {AbortSignal} abortSignal - An AbortSignal to cancel the request if needed.
+   * @param {object} [customOptions] - Optional provider-specific parameters (e.g., temperature, max_tokens).
+   * @returns {Promise<AsyncGenerator<SSEChatCompletionMessage, void, undefined>>} A stream of incremental chat completion updates.
+   * @throws {Error} If the request fails or the model is unavailable.
+   */
   postChatCompletions(
     model: string,
     messages: readonly InferenceApiMessage[],
     abortSignal: AbortSignal,
     customOptions?: object
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Promise<AsyncGenerator<any, void, unknown>>;
+  ): Promise<AsyncGenerator<SSEChatCompletionMessage, void, undefined>>;
 }
 
+/**
+ * Combined interface that aggregates all required capabilities for a complete inference provider.
+ * Extends `LLMProvider`, `ModelProvider`, and `ChatCompletionProvider` to provide a unified API.
+ * Implementations should handle model discovery, authentication, and streaming chat completions.
+ * @interface
+ * @extends {LLMProvider}
+ * @extends {ModelProvider}
+ * @extends {ChatCompletionProvider}
+ */
 export interface InferenceProvider
   extends LLMProvider,
     ModelProvider,


### PR DESCRIPTION
- Remove @sec-ant/readable-stream and textlinestream dependencies
- Implement native SSE stream processing using ReadableStream and TextDecoder
- Add proper SSE message parsing with data, error, event, id, and retry fields
- Add proper type definitions for SSE messages and chat completion streams
- Update BaseOpenAIProvider to use new processSSEStream function
- Convert TimingReport fields to optional to handle missing data gracefully
- Update chat context to handle both timings and usage data structures
- Improve ChatMessage component to conditionally render timing information