### PR TITLE
perf(chat): add throttling to pending messages for smoother UI updates

### DIFF
--- a/src/hooks/useFrameRateLimit.ts
+++ b/src/hooks/useFrameRateLimit.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+function useFrameRateLimit<T>(value: T, targetFPS: number = 25) {
+  const [displayedValue, setDisplayedValue] = useState<T>(value);
+  const targetFrameTime = 1000 / targetFPS; // ms per frame
+  const lastFrameTimeRef = useRef<number>(0);
+  const pendingValueRef = useRef<T | null>(null);
+  const animationFrameRef = useRef<number>(0);
+
+  const updateFrame = useCallback(
+    (timestamp: number) => {
+      if (timestamp - lastFrameTimeRef.current >= targetFrameTime) {
+        if (pendingValueRef.current !== null) {
+          setDisplayedValue(pendingValueRef.current);
+          pendingValueRef.current = null;
+          lastFrameTimeRef.current = timestamp;
+        }
+      }
+
+      animationFrameRef.current = requestAnimationFrame(updateFrame);
+    },
+    [targetFrameTime]
+  );
+
+  useEffect(() => {
+    pendingValueRef.current = value;
+
+    if (!animationFrameRef.current) {
+      animationFrameRef.current = requestAnimationFrame(updateFrame);
+    }
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [value, updateFrame]);
+
+  return displayedValue;
+}
+
+export default useFrameRateLimit;

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from 'react';
+
+function useThrottle<T>(value: T, delay: number): T {
+  const [throttledValue, setThrottledValue] = useState<T>(value);
+  const lastUpdateRef = useRef<number>(0);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    const timeSinceLastUpdate = now - lastUpdateRef.current;
+
+    if (timeSinceLastUpdate > delay) {
+      // Update immediately if enough time has passed
+      setThrottledValue(value);
+      lastUpdateRef.current = now;
+    } else {
+      // Schedule update for when delay is reached
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        setThrottledValue(value);
+        lastUpdateRef.current = Date.now();
+      }, delay - timeSinceLastUpdate);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [value, delay]);
+
+  return throttledValue;
+}
+
+export default useThrottle;


### PR DESCRIPTION
- Introduces useThrottle hook to limit pending message updates to 3.33 FPS
- Reduces UI jank during rapid message generation
- Improves perceived performance by preventing excessive re-renders

relates: #179 