### PR TITLE
fix(api): cache provider instance with correct cache key

### DIFF
--- a/src/api/providers/BaseOpenAIProvider.ts
+++ b/src/api/providers/BaseOpenAIProvider.ts
@@ -134,7 +134,7 @@ export class BaseOpenAIProvider
     const json = await fetchResponse.json();
     this.models = this.jsonToModels(json.data);
 
-    this.lastUpdated = Date.now();
+    if (this.models.length > 0) this.lastUpdated = Date.now();
 
     return this.models;
   }

--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -44,6 +44,6 @@ export function getInferenceProvider(
       provider = BaseOpenAIProvider.new(baseUrl, apiKey);
   }
 
-  PROVIDER_CACHE.set(baseUrl, provider);
+  PROVIDER_CACHE.set(cacheKey, provider);
   return provider;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,22 +113,6 @@ export default defineConfig({
               },
             },
           },
-          {
-            urlPattern: ({ request }) =>
-              request.url.endsWith('/v1/models') &&
-              !request.url.includes('localhost') &&
-              !/(127\.\d{1,3}\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3})/.test(
-                request.url
-              ),
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'api-models',
-              expiration: {
-                maxEntries: 20,
-                maxAgeSeconds: 60 * 15, // 15 minutes
-              },
-            },
-          },
         ],
       },
     }),


### PR DESCRIPTION
- Use cacheKey instead of baseUrl when caching provider instances
- Only update lastUpdated timestamp when models array is not empty
- Remove caching strategy for /v1/models endpoint from SW config