### PR TITLE
refactor(settings): extract settings components to separate modules

### DIFF
--- a/src/components/settings/ImportExportComponent.tsx
+++ b/src/components/settings/ImportExportComponent.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from 'react-i18next';
+import { LuEye, LuMessageCircleMore } from 'react-icons/lu';
+import { TbDatabaseExport, TbDatabaseImport } from 'react-icons/tb';
+import { DelimeterComponent, SettingsSectionLabel } from '.';
+import { useAppContext } from '../../context/app';
+import { normalizeUrl } from '../../utils';
+import { downloadAsFile } from '../common';
+
+export function ImportExportComponent({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const { importDB, exportDB } = useAppContext();
+
+  const onExport = async () => {
+    return exportDB().then((data) =>
+      downloadAsFile([JSON.stringify(data, null, 2)], 'llama-ui-database.json')
+    );
+  };
+
+  const onImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length != 1) return false;
+    const data = await files[0].text();
+    await importDB(data);
+    onClose();
+  };
+
+  const debugImportDemoConv = async () => {
+    const res = await fetch(
+      normalizeUrl('/demo-conversation.json', import.meta.env.BASE_URL)
+    );
+    if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+    const data = await res.text();
+    await importDB(data);
+    onClose();
+  };
+
+  return (
+    <>
+      <SettingsSectionLabel>
+        <LuMessageCircleMore className="lucide w-4 h-4 mr-1 inline" />
+        {t('settings.importExport.chatsSectionTitle')}
+      </SettingsSectionLabel>
+
+      <div className="grid grid-cols-[repeat(2,max-content)] gap-2">
+        <button className="btn" onClick={onExport}>
+          <TbDatabaseExport className="lucide w-4 h-4 mr-1 inline" />
+          {t('settings.importExport.exportBtnLabel')}
+        </button>
+
+        <input
+          id="file-import"
+          type="file"
+          accept=".json"
+          onInput={onImport}
+          hidden
+        />
+        <label
+          htmlFor="file-import"
+          className="btn"
+          aria-label={t('settings.importExport.importBtnLabel')}
+          tabIndex={0}
+          role="button"
+        >
+          <TbDatabaseImport className="lucide w-4 h-4 mr-1 inline" />
+          {t('settings.importExport.importBtnLabel')}
+        </label>
+      </div>
+
+      <DelimeterComponent />
+
+      <SettingsSectionLabel>
+        <LuEye className="lucide w-4 h-4 mr-1 inline" />
+        {t('settings.importExport.technicalDemoSectionTitle')}
+      </SettingsSectionLabel>
+
+      <button className="btn" onClick={debugImportDemoConv}>
+        {t('settings.importExport.importDemoConversationBtnLabel')}
+      </button>
+    </>
+  );
+}

--- a/src/components/settings/ThemeController.tsx
+++ b/src/components/settings/ThemeController.tsx
@@ -1,0 +1,106 @@
+import { useMemo } from 'react';
+import { Trans } from 'react-i18next';
+import { SYNTAX_THEMES, THEMES } from '../../config';
+import { useAppContext } from '../../context/app';
+import { Dropdown, DropdownOption } from '../common';
+
+export function ThemeController() {
+  const dataThemes = ['auto', ...THEMES].map((theme) => ({
+    value: theme,
+    label: theme,
+  }));
+  const syntaxThemes = ['auto', ...SYNTAX_THEMES].map((theme) => ({
+    value: theme,
+    label: theme,
+  }));
+
+  const { currentTheme, switchTheme, currentSyntaxTheme, switchSyntaxTheme } =
+    useAppContext();
+
+  const selectedThemeValue = useMemo(
+    () => (
+      <div className="flex gap-2 items-center ml-2">
+        <span
+          data-theme={currentTheme}
+          className="bg-base-100 grid shrink-0 grid-cols-2 gap-1 rounded-md p-1 shadow-sm"
+        >
+          <div className="bg-base-content size-1 rounded-full"></div>{' '}
+          <div className="bg-primary size-1 rounded-full"></div>{' '}
+          <div className="bg-secondary size-1 rounded-full"></div>{' '}
+          <div className="bg-accent size-1 rounded-full"></div>
+        </span>
+        <span className="truncate text-left">{currentTheme}</span>
+      </div>
+    ),
+    [currentTheme]
+  );
+  const renderThemeOption = (option: DropdownOption) => (
+    <div className="flex gap-2 items-center">
+      <span
+        data-theme={option.value}
+        className="bg-base-100 grid shrink-0 grid-cols-2 gap-0.5 rounded-md p-1 shadow-sm"
+      >
+        <div className="bg-base-content size-1 rounded-full"></div>{' '}
+        <div className="bg-primary size-1 rounded-full"></div>{' '}
+        <div className="bg-secondary size-1 rounded-full"></div>{' '}
+        <div className="bg-accent size-1 rounded-full"></div>
+      </span>
+      <span className="truncate text-left">{option.label}</span>
+    </div>
+  );
+
+  /* theme controller is copied from https://daisyui.com/components/theme-controller/ */
+  return (
+    <>
+      {/* UI theme */}
+      <div className="form-control flex flex-col justify-center mb-3">
+        <div className="font-bold mb-1 md:hidden">
+          <Trans i18nKey="settings.themeManager.dataTheme.label" />
+        </div>
+        <label className="input input-bordered join-item grow flex items-center gap-2 mb-1">
+          <div className="font-bold hidden md:block">
+            <Trans i18nKey="settings.themeManager.dataTheme.label" />
+          </div>
+
+          <Dropdown
+            className="grow"
+            entity="theme"
+            options={dataThemes}
+            currentValue={selectedThemeValue}
+            renderOption={renderThemeOption}
+            isSelected={(option) => currentTheme === option.value}
+            onSelect={(option) => switchTheme(option.value)}
+          />
+        </label>
+        <div className="text-xs opacity-75 max-w-80">
+          <Trans i18nKey="settings.themeManager.dataTheme.note" />
+        </div>
+      </div>
+
+      {/* Code blocks theme */}
+      <div className="form-control flex flex-col justify-center mb-3">
+        <div className="font-bold mb-1 md:hidden">
+          <Trans i18nKey="settings.themeManager.syntaxTheme.label" />
+        </div>
+        <label className="input input-bordered join-item grow flex items-center gap-2 mb-1">
+          <div className="font-bold hidden md:block">
+            <Trans i18nKey="settings.themeManager.syntaxTheme.label" />
+          </div>
+
+          <Dropdown
+            className="grow"
+            entity="theme"
+            options={syntaxThemes}
+            currentValue={<span>{currentSyntaxTheme}</span>}
+            renderOption={(option) => <span>{option.label}</span>}
+            isSelected={(option) => currentSyntaxTheme === option.value}
+            onSelect={(option) => switchSyntaxTheme(option.value)}
+          />
+        </label>
+        <div className="text-xs opacity-75 max-w-80">
+          <Trans i18nKey="settings.themeManager.syntaxTheme.note" />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/settings/common.tsx
+++ b/src/components/settings/common.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CONFIG_DEFAULT } from '../../config';
+import { DropdownOption, SettingFieldInput } from '../../types/settings';
+import { classNames, normalizeUrl } from '../../utils';
+import { Dropdown } from '../common';
+
+interface BaseInputProps {
+  field: SettingFieldInput;
+  onChange: (value: string | number | boolean) => void;
+}
+
+interface LabeledFieldProps {
+  children: (props: LabeledFieldState) => React.ReactNode;
+  configKey: string;
+}
+interface LabeledFieldState {
+  label: string | React.ReactElement;
+  note?: string | TrustedHTML;
+}
+
+function LabeledField({ children, configKey }: LabeledFieldProps) {
+  const { t } = useTranslation();
+
+  const { label, note } = useMemo(() => {
+    if (!configKey) return { label: '', note: '' };
+    return {
+      label:
+        t(`settings.parameters.${configKey}.label`, {
+          defaultValue: configKey,
+        }) || configKey,
+      note: t(`settings.parameters.${configKey}.note`, {
+        defaultValue: '',
+      }),
+    };
+  }, [t, configKey]);
+
+  return <>{children({ label, note })}</>;
+}
+
+export function SettingsModalLongInput({
+  field,
+  value,
+  onChange,
+}: BaseInputProps & { value: string }) {
+  return (
+    <LabeledField configKey={field.translateKey || field.key}>
+      {({ label, note }) => (
+        <label className="form-control flex flex-col justify-center max-w-80 mb-3">
+          <div className="text-sm opacity-60 mb-1">{label}</div>
+          <textarea
+            className="textarea textarea-bordered h-24"
+            placeholder={`Default: ${CONFIG_DEFAULT[field.key] || 'none'}`}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={field.disabled}
+          />
+          {note && (
+            <div
+              className="text-xs opacity-75 mt-1"
+              dangerouslySetInnerHTML={{ __html: note }}
+            />
+          )}
+        </label>
+      )}
+    </LabeledField>
+  );
+}
+
+export function SettingsModalShortInput({
+  field,
+  value,
+  onChange,
+}: BaseInputProps & { value: string | number }) {
+  return (
+    <LabeledField configKey={field.translateKey || field.key}>
+      {({ label, note }) => (
+        <label className="form-control flex flex-col justify-center mb-3">
+          <div tabIndex={0} role="button" className="font-bold mb-1 md:hidden">
+            {label}
+          </div>
+          <label className="input input-bordered join-item grow flex items-center gap-2 mb-1">
+            <div
+              tabIndex={0}
+              role="button"
+              className="font-bold hidden md:block"
+            >
+              {label}
+            </div>
+            <input
+              type="text"
+              className="grow"
+              placeholder={`Default: ${CONFIG_DEFAULT[field.key] || 'none'}`}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={field.disabled}
+            />
+          </label>
+          {note && (
+            <div
+              className="text-xs opacity-75 max-w-80"
+              dangerouslySetInnerHTML={{ __html: note }}
+            />
+          )}
+        </label>
+      )}
+    </LabeledField>
+  );
+}
+
+export function SettingsModalRangeInput({
+  field,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: BaseInputProps & {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+}) {
+  const values = useMemo(() => {
+    const fractionDigits =
+      Math.floor(step) === step ? 0 : step.toString().split('.')[1].length || 0;
+
+    const length = Math.floor((max - min) / step) + 1;
+    return Array.from({ length }, (_, i) =>
+      Number(min + i * step).toFixed(fractionDigits)
+    );
+  }, [max, min, step]);
+
+  return (
+    <LabeledField configKey={field.translateKey || field.key}>
+      {({ label, note }) => (
+        <label className="form-control flex flex-col justify-center mb-3">
+          <div tabIndex={0} role="button" className="font-bold mb-1 md:hidden">
+            {label}
+          </div>
+          <label className="input input-bordered join-item grow flex items-center gap-2 mb-1">
+            <div
+              tabIndex={0}
+              role="button"
+              className="font-bold hidden md:block"
+            >
+              {label}
+            </div>
+            <div className="grow px-2">
+              <input
+                type="range"
+                className="range range-xs [--range-fill:0]"
+                min={min}
+                max={max}
+                step={step}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                disabled={field.disabled}
+              />
+              <div className="flex justify-between text-xs">
+                {values.map((v) => (
+                  <span key={v}>{v}</span>
+                ))}
+              </div>
+            </div>
+          </label>
+          {note && (
+            <div
+              className="text-xs opacity-75 max-w-80"
+              dangerouslySetInnerHTML={{ __html: note }}
+            />
+          )}
+        </label>
+      )}
+    </LabeledField>
+  );
+}
+
+export function SettingsModalCheckbox({
+  field,
+  value,
+  onChange,
+}: BaseInputProps & { value: boolean }) {
+  return (
+    <LabeledField configKey={field.translateKey || field.key}>
+      {({ label, note }) => (
+        <label className="form-control flex flex-col justify-center mb-3">
+          <div className="flex flex-row items-center mb-1">
+            <input
+              type="checkbox"
+              className="toggle"
+              checked={value}
+              onChange={(e) => onChange(e.target.checked)}
+              disabled={field.disabled}
+            />
+            <span className="ml-2">{label}</span>
+          </div>
+          {note && (
+            <div
+              className="text-xs opacity-75 max-w-80 mt-1"
+              dangerouslySetInnerHTML={{ __html: note }}
+            />
+          )}
+        </label>
+      )}
+    </LabeledField>
+  );
+}
+
+export function SettingsModalDropdown({
+  field,
+  options,
+  filterable = false,
+  value,
+  onChange,
+}: BaseInputProps & {
+  options: DropdownOption[];
+  filterable?: boolean;
+  value: string;
+}) {
+  const renderOption = (option: DropdownOption) => (
+    <span className="truncate">
+      {option.icon && (
+        <img
+          src={normalizeUrl(option.icon, import.meta.env.BASE_URL)}
+          className="inline h-5 w-5 mr-2"
+        />
+      )}
+      {option.label}
+    </span>
+  );
+
+  const disabled = useMemo(() => options.length < 2, [options]);
+  const selectedValue = useMemo(() => {
+    const selectedOption = options.find((option) => option.value === value);
+    return selectedOption ? (
+      <span className="max-w-48 truncate text-nowrap">
+        {selectedOption.label}
+      </span>
+    ) : (
+      ''
+    );
+  }, [options, value]);
+
+  useEffect(() => {
+    if (
+      options.length > 0 &&
+      !options.some((option) => option.value === value)
+    ) {
+      onChange(options[0].value);
+    }
+  }, [options, value, onChange]);
+
+  return (
+    <LabeledField configKey={field.translateKey || field.key}>
+      {({ label, note }) => (
+        <div className="form-control flex flex-col justify-center mb-3">
+          <div className="font-bold mb-1 md:hidden">{label}</div>
+          <label
+            className={classNames({
+              'input input-bordered join-item grow flex items-center gap-2 mb-1': true,
+              'bg-base-200': disabled,
+            })}
+          >
+            <div className="font-bold hidden md:block">{label}</div>
+
+            <Dropdown
+              className="grow"
+              entity={field.key}
+              options={options}
+              filterable={filterable}
+              optionsSize={filterable ? 'small' : 'medium'}
+              currentValue={selectedValue}
+              renderOption={renderOption}
+              isSelected={(option) => value === option.value}
+              onSelect={(option) => onChange(option.value)}
+            />
+          </label>
+
+          {note && (
+            <div
+              className="text-xs opacity-75 max-w-80"
+              dangerouslySetInnerHTML={{ __html: note }}
+            />
+          )}
+        </div>
+      )}
+    </LabeledField>
+  );
+}
+
+export function SettingsSectionLabel({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-2">
+      <h4>{children}</h4>
+    </div>
+  );
+}
+
+export function DelimeterComponent() {
+  return <div className="pb-3" aria-label="delimeter" />;
+}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,0 +1,4 @@
+export * from './common';
+export * from './ImportExportComponent';
+export * from './PresetManager';
+export * from './ThemeController';

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,75 @@
+import { ReactNode } from 'react';
+import { ConfigurationKey } from '.';
+
+export enum SettingInputType {
+  SHORT_INPUT,
+  LONG_INPUT,
+  RANGE_INPUT,
+  CHECKBOX,
+  DROPDOWN,
+  CUSTOM,
+  SECTION,
+}
+
+export type SettingFieldInputType = Exclude<
+  SettingInputType,
+  SettingInputType.CUSTOM | SettingInputType.SECTION
+>;
+
+export interface BaseSettingField {
+  key: ConfigurationKey;
+  disabled?: boolean;
+  translateKey?: string;
+  [key: string]: unknown;
+}
+
+export interface SettingFieldInput extends BaseSettingField {
+  type: SettingFieldInputType;
+}
+
+export interface SettingFieldCustom {
+  type: SettingInputType.CUSTOM;
+  key:
+    | ConfigurationKey
+    | 'custom'
+    | 'language'
+    | 'import-export'
+    | 'preset-manager'
+    | 'fetch-models'
+    | 'theme-manager';
+  component:
+    | string
+    | React.FC<{
+        value: string | boolean | number;
+        onChange: (value: string | boolean) => void;
+      }>
+    | 'delimeter';
+}
+
+export interface DropdownOption {
+  value: string | number;
+  label: string;
+  icon?: string;
+}
+
+export interface SettingFieldDropdown extends BaseSettingField {
+  type: SettingInputType.DROPDOWN;
+  options: DropdownOption[];
+  filterable: boolean;
+}
+
+export interface SettingSection {
+  type: SettingInputType.SECTION;
+  label: string | ReactNode;
+}
+
+export type SettingField =
+  | SettingFieldInput
+  | SettingFieldCustom
+  | SettingSection
+  | SettingFieldDropdown;
+
+export interface SettingTab {
+  title: ReactNode;
+  fields: SettingField[];
+}


### PR DESCRIPTION
- Move input components (SettingsModalShortInput, SettingsModalLongInput, etc.) to common.tsx
- Extract PresetManager component to its own file
- Extract ThemeController component to its own file
- Extract ImportExportComponent to its own file
- Consolidate settings-related type definitions in new settings.ts file