### PR TITLE
style(chat): expand ChatInput on focus

### DIFF
--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -18,7 +18,7 @@ const variants = cva('textarea min-h-auto resize-none', {
       default: 'focus:outline-1 focus:outline-offset-0',
       code: 'font-mono',
       transparent:
-        'bg-transparent border-none outline-none ring-0 focus:outline-none focus:ring-0',
+        'bg-transparent border-none outline-0 ring-0 focus:outline-0 focus:ring-0',
     },
     size: {
       default: 'h-24',

--- a/src/pages/Chat/components/ChatInput.tsx
+++ b/src/pages/Chat/components/ChatInput.tsx
@@ -93,7 +93,7 @@ export const ChatInput = memo(
 
     return (
       <div
-        className="shrink-0 w-full lg:max-w-[900px] bg-base-100 mx-auto p-1 md:p-2"
+        className="group shrink-0 w-full md:max-w-md focus-within:md:max-w-2xl lg:max-w-lg focus-within:lg:max-w-3xl xl:max-w-3xl focus-within:xl:max-w-4xl bg-base-100 mx-auto p-1 md:p-2"
         aria-label={t('chatInput.ariaLabels.chatInput')}
       >
         <DropzoneArea
@@ -101,11 +101,14 @@ export const ChatInput = memo(
           extraContext={extraContext}
           disabled={isPending}
         >
-          <div className="bg-base-200 flex flex-col lg:border-1 lg:border-base-content/30 rounded-lg shadow-sm md:shadow-md p-2">
+          <div
+            className="bg-base-200 flex flex-col lg:border-1 lg:border-base-content/30 outline-0 focus-within:outline-1 rounded-lg shadow-sm md:shadow-md p-2"
+            tabIndex={0}
+          >
             <AutoSizingTextArea
               // Default (mobile): Enable vertical resize, overflow auto for scrolling if needed
               // Large screens (lg:): Disable manual resize, apply max-height for autosize limit
-              className="text-base p-0 px-2"
+              className="text-base p-0 px-2 max-md:min-h-12"
               variant="transparent"
               size="full"
               placeholder={t('chatInput.placeholder')}
@@ -119,14 +122,11 @@ export const ChatInput = memo(
                   sendNewMessage();
                 }
               }}
-              id="msg-input"
-              // Set a base height of 2 rows for mobile views
-              // On lg+ screens, the hook will calculate and set the initial height anyway
-              rows={2}
+              rows={1}
             />
 
             {/* buttons area */}
-            <div className="flex items-center justify-between mt-2">
+            <div className="hidden group-focus-within:flex items-center justify-between mt-2">
               <div className="flex gap-2 items-center">
                 <Label
                   className={isPending ? 'btn-disabled' : ''}

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -191,7 +191,7 @@ export default function ChatScreen({
           {/* chat messages */}
           <div
             className={classNames({
-              'flex flex-col w-full xl:max-w-[900px] mx-auto': true,
+              'flex flex-col w-full xl:max-w-4xl mx-auto': true,
               'hidden xl:flex': hasCanvas, // adapted for mobile
               flex: !hasCanvas,
             })}

--- a/src/pages/Welcome/index.tsx
+++ b/src/pages/Welcome/index.tsx
@@ -50,7 +50,7 @@ export default function WelcomeScreen() {
   );
 
   return (
-    <div className="flex flex-col h-full w-full xl:max-w-[900px] mx-auto">
+    <div className="flex flex-col h-full w-full xl:max-w-4xl mx-auto">
       <div className="grow flex flex-col items-center justify-center px-2 transition-[300ms]">
         <h1 className="text-4xl font-medium">
           <Trans i18nKey="welcomeScreen.welcome" />


### PR DESCRIPTION
- Replace outline-none with outline-0 for transparent textarea variant
- Add responsive max-width classes to chat input container with focus expansion
- Add outline and focus styles to chat input wrapper
- Set min-height for mobile text area and change default rows to 1
- Hide buttons area by default, show on input focus
- Update max-width from fixed value to xl:4xl for chat and welcome screens