### PR TITLE
fix(inference): update condition for loading models

### DIFF
--- a/src/store/inference.tsx
+++ b/src/store/inference.tsx
@@ -232,7 +232,7 @@ export const InferenceContextProvider = ({
         updateApi(config);
       }
 
-      if (Object.is(prevConfig, CONFIG_DEFAULT) && !!config.baseUrl) {
+      if (Object.is(prevConfig, CONFIG_DEFAULT) || !!config.baseUrl) {
         loadModels(config);
       }
 


### PR DESCRIPTION
- Change condition from Object.is(prevConfig, CONFIG_DEFAULT) AND !!config.baseUrl to Object.is(prevConfig, CONFIG_DEFAULT) OR !!config.baseUrl
- This ensures models are loaded when either the config changes from default OR when a baseUrl is provided