### PR TITLE
refactor(icon): migrate to direct icon component usage

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuChevronDown } from 'react-icons/lu';
 import { isDev } from '../config';
 import { classNames } from '../utils';
 import { Button } from './Button';
@@ -114,7 +115,9 @@ export function Dropdown<T extends DropdownOption>({
           >
             {currentValue}
             {!hideChevron && (
-              <Icon icon="LuChevronDown" variant="rightside" size="md" />
+              <Icon variant="rightside" size="md">
+                <LuChevronDown />
+              </Icon>
             )}
           </summary>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuCog, LuMenu, LuSquarePen } from 'react-icons/lu';
 import { useNavigate } from 'react-router';
 import { useAppContext } from '../store/app';
 import { useChatContext } from '../store/chat';
@@ -42,7 +43,9 @@ export default function Header() {
       <section className="flex flex-row items-center xl:hidden">
         {/* open sidebar button */}
         <Label variant="btn-ghost" size="icon" htmlFor="toggle-drawer">
-          <Icon icon="LuMenu" size="md" />
+          <Icon size="md">
+            <LuMenu />
+          </Icon>
         </Label>
 
         {/* spacer */}
@@ -68,7 +71,9 @@ export default function Header() {
           title={t('header.buttons.newConv')}
           aria-label={t('header.ariaLabels.newConv')}
         >
-          <Icon icon="LuSquarePen" size="md" />
+          <Icon size="md">
+            <LuSquarePen />
+          </Icon>
         </Button>
       </section>
 
@@ -129,7 +134,9 @@ export default function Header() {
               onClick={() => navigate('/settings')}
             >
               {/* settings button */}
-              <Icon icon="LuCog" size="md" />
+              <Icon size="md">
+                <LuCog />
+              </Icon>
             </Button>
           </div>
         </section>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,10 +1,7 @@
 import { cva, VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 import { IconBaseProps } from 'react-icons';
-import * as LucideIcons from 'react-icons/lu';
 import { cn } from '../utils';
-
-type IconNames = keyof Omit<typeof LucideIcons, 'IconContext'>;
 
 const iconVariants = cva('', {
   variants: {
@@ -34,36 +31,28 @@ type IconProps = Omit<IconBaseProps, 'size'> &
   VariantProps<typeof iconVariants> &
   React.SVGAttributes<SVGSVGElement> & {
     className?: string;
-    icon: IconNames;
+    children: React.ReactElement<IconBaseProps>;
   };
 
 const Icon = React.forwardRef<SVGSVGElement, IconProps>(
-  ({ className, library = 'lucide', variant, size, icon, ...props }, ref) => {
-    let SelectedIcon: React.ElementType;
-
-    switch (library) {
-      case 'lucide':
-        SelectedIcon = LucideIcons[icon];
-        break;
-      default:
-        throw new Error(`Library "${library}" not found in icons`);
+  ({ className, variant, size, children, ...props }, ref) => {
+    if (!children) {
+      throw new Error('Icon component requires a child icon element');
     }
 
-    if (!SelectedIcon) {
-      throw new Error(`Icon "${icon}" not found in Lucide icons`);
-    }
+    const iconElement = React.cloneElement(children, {
+      className: cn(
+        iconVariants({ variant, size, className }),
+        children.props.className
+      ),
+      ref,
+      ...props,
+    });
 
-    return (
-      <SelectedIcon
-        ref={ref}
-        className={cn(iconVariants({ library, variant, size, className }))}
-        {...props}
-      />
-    );
+    return iconElement;
   }
 );
 
 Icon.displayName = 'Icon';
 
-export default Icon;
 export { Icon };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,15 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
+import {
+  LuDownload,
+  LuEllipsisVertical,
+  LuPencil,
+  LuSearch,
+  LuSquarePen,
+  LuTrash,
+  LuX,
+} from 'react-icons/lu';
 import { useNavigate } from 'react-router';
 import IndexedDB from '../database/indexedDB';
 import useFilter from '../hooks/useFilter';
@@ -82,7 +91,9 @@ export default function Sidebar() {
               aria-label={t('sidebar.buttons.closeSideBar')}
               tabIndex={0}
             >
-              <Icon icon="LuX" size="md" />
+              <Icon size="md">
+                <LuX />
+              </Icon>
             </Label>
 
             <Label
@@ -103,7 +114,9 @@ export default function Sidebar() {
               title={t('header.buttons.newConv')}
               aria-label={t('header.ariaLabels.newConv')}
             >
-              <Icon icon="LuSquarePen" size="md" />
+              <Icon size="md">
+                <LuSquarePen />
+              </Icon>
             </Button>
           </div>
 
@@ -113,7 +126,9 @@ export default function Sidebar() {
               variant="input-bordered"
               className="h-8 inset-shadow-sm my-1.5 px-1.5"
             >
-              <Icon icon="LuSearch" size="md" />
+              <Icon size="md">
+                <LuSearch />
+              </Icon>
               <Input
                 className="input-sm grow"
                 name="Search"
@@ -137,7 +152,9 @@ export default function Sidebar() {
                   title={t('header.buttons.clear')}
                   aria-label={t('header.ariaLabels.clear')}
                 >
-                  <Icon icon="LuX" size="md" />
+                  <Icon size="md">
+                    <LuX />
+                  </Icon>
                 </Button>
               )}
             </Label>
@@ -313,7 +330,9 @@ const ConversationItem = memo(
             title={t('sidebar.buttons.more')}
             aria-label={t('sidebar.ariaLabels.more')}
           >
-            <Icon icon="LuEllipsisVertical" size="md" />
+            <Icon size="md">
+              <LuEllipsisVertical />
+            </Icon>
           </Button>
           {/* dropdown menu */}
           <ul
@@ -329,7 +348,9 @@ const ConversationItem = memo(
                 title={t('sidebar.buttons.rename')}
                 aria-label={t('sidebar.ariaLabels.rename')}
               >
-                <Icon icon="LuPencil" size="sm" />
+                <Icon size="sm">
+                  <LuPencil />
+                </Icon>
                 <Trans i18nKey="sidebar.buttons.rename" />
               </Button>
             </li>
@@ -340,7 +361,9 @@ const ConversationItem = memo(
                 title={t('sidebar.buttons.download')}
                 aria-label={t('sidebar.ariaLabels.download')}
               >
-                <Icon icon="LuDownload" size="sm" />
+                <Icon size="sm">
+                  <LuDownload />
+                </Icon>
                 <Trans i18nKey="sidebar.buttons.download" />
               </Button>
             </li>
@@ -356,7 +379,9 @@ const ConversationItem = memo(
                 title={t('sidebar.buttons.delete')}
                 aria-label={t('sidebar.ariaLabels.delete')}
               >
-                <Icon icon="LuTrash" size="sm" />
+                <Icon size="sm">
+                  <LuTrash />
+                </Icon>
                 <Trans i18nKey="sidebar.buttons.delete" />
               </Button>
             </li>

--- a/src/pages/Chat/components/CanvasPyInterpreter.tsx
+++ b/src/pages/Chat/components/CanvasPyInterpreter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuPlay, LuSquare, LuX } from 'react-icons/lu';
 import { Button, Icon, TextArea } from '../../../components';
 import LocalStorage from '../../../database/localStorage';
 import { useChatContext } from '../../../store/chat';
@@ -158,7 +159,9 @@ export default function CanvasPyInterpreter() {
             title={t('codeRunner.buttons.close')}
             onClick={() => setCanvasData(null)}
           >
-            <Icon icon="LuX" size="md" />
+            <Icon size="md">
+              <LuX />
+            </Icon>
           </Button>
         </div>
         <div className="grid grid-rows-3 gap-4 h-full">
@@ -176,7 +179,9 @@ export default function CanvasPyInterpreter() {
                 onClick={() => runCode(code)}
                 disabled={running}
               >
-                <Icon icon="LuPlay" variant="leftside" size="md" />
+                <Icon variant="leftside" size="md">
+                  <LuPlay />
+                </Icon>
                 {t('codeRunner.buttons.run')}
               </Button>
               {showStopBtn && (
@@ -186,7 +191,9 @@ export default function CanvasPyInterpreter() {
                   title={t('codeRunner.buttons.stop')}
                   onClick={() => interruptFn?.()}
                 >
-                  <Icon icon="LuSquare" variant="leftside" size="md" />
+                  <Icon variant="leftside" size="md">
+                    <LuSquare />
+                  </Icon>
                   {t('codeRunner.buttons.stop')}
                 </Button>
               )}

--- a/src/pages/Chat/components/ChatInput.tsx
+++ b/src/pages/Chat/components/ChatInput.tsx
@@ -9,6 +9,13 @@ import {
 } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import {
+  LuArrowUp,
+  LuCircleStop,
+  LuMic,
+  LuPaperclip,
+  LuSquare,
+} from 'react-icons/lu';
 import { TbAdjustmentsHorizontal } from 'react-icons/tb';
 import { useNavigate } from 'react-router';
 import { AutoSizingTextArea, Button, Icon, Label } from '../../../components';
@@ -137,7 +144,9 @@ export const ChatInput = memo(
                   tabIndex={0}
                   role="button"
                 >
-                  <Icon icon="LuPaperclip" size="md" />
+                  <Icon size="md">
+                    <LuPaperclip />
+                  </Icon>
                 </Label>
 
                 <Button
@@ -166,7 +175,9 @@ export const ChatInput = memo(
                             title="Record"
                             aria-label="Start Recording"
                           >
-                            <Icon icon="LuMic" size="md" />
+                            <Icon size="md">
+                              <LuMic />
+                            </Icon>
                           </Button>
                         )}
                         {isRecording && (
@@ -178,7 +189,9 @@ export const ChatInput = memo(
                             title="Stop"
                             aria-label="Stop Recording"
                           >
-                            <Icon icon="LuCircleStop" size="md" />
+                            <Icon size="md">
+                              <LuCircleStop />
+                            </Icon>
                           </Button>
                         )}
                       </>
@@ -188,7 +201,9 @@ export const ChatInput = memo(
 
                 {isPending && (
                   <Button variant="neutral" size="icon-xl" onClick={handleStop}>
-                    <Icon icon="LuSquare" size="sm" variant="current" />
+                    <Icon size="sm" variant="current">
+                      <LuSquare />
+                    </Icon>
                   </Button>
                 )}
 
@@ -199,7 +214,9 @@ export const ChatInput = memo(
                     onClick={sendNewMessage}
                     aria-label={t('chatInput.ariaLabels.send')}
                   >
-                    <Icon icon="LuArrowUp" size="md" />
+                    <Icon size="md">
+                      <LuArrowUp />
+                    </Icon>
                   </Button>
                 )}
               </div>

--- a/src/pages/Chat/components/ChatInputExtraContextItem.tsx
+++ b/src/pages/Chat/components/ChatInputExtraContextItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuFileText, LuVolume2, LuX } from 'react-icons/lu';
 import { Button, Icon } from '../../../components';
 import { MessageExtra } from '../../../types';
 import { classNames } from '../../../utils';
@@ -46,7 +47,9 @@ export default function ChatInputExtraContextItem({
                 size="icon-sm"
                 onClick={() => removeItem(i)}
               >
-                <Icon icon="LuX" size="xs" />
+                <Icon size="xs">
+                  <LuX />
+                </Icon>
               </Button>
             </div>
           )}
@@ -72,17 +75,13 @@ export default function ChatInputExtraContextItem({
                   aria-description={t('chatInput.ariaLabels.documentIcon')}
                 >
                   {item.type === 'audioFile' ? (
-                    <Icon
-                      icon="LuVolume2"
-                      size="xl"
-                      className="text-gray-500"
-                    />
+                    <Icon size="xl" className="text-gray-500">
+                      <LuVolume2 />
+                    </Icon>
                   ) : (
-                    <Icon
-                      icon="LuFileText"
-                      size="xl"
-                      className="text-gray-500"
-                    />
+                    <Icon size="xl" className="text-gray-500">
+                      <LuFileText />
+                    </Icon>
                   )}
                 </div>
 
@@ -110,7 +109,9 @@ export default function ChatInputExtraContextItem({
                 size="small"
                 aria-label={t('chatInput.previewDialog.closeButton')}
               >
-                <Icon icon="LuX" size="md" onClick={() => setShow(-1)} />
+                <Icon size="md" onClick={() => setShow(-1)}>
+                  <LuX />
+                </Icon>
               </Button>
             </div>
             {showingItem.type === 'imageFile' ? (

--- a/src/pages/Chat/components/ChatMessage.tsx
+++ b/src/pages/Chat/components/ChatMessage.tsx
@@ -5,6 +5,22 @@ import {
 } from '@radix-ui/react-collapsible';
 import { memo, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import {
+  LuAtom,
+  LuBrain,
+  LuChevronDown,
+  LuChevronLeft,
+  LuChevronRight,
+  LuCopy,
+  LuGauge,
+  LuGitMerge,
+  LuPaperclip,
+  LuRefreshCw,
+  LuSquarePen,
+  LuTrash2,
+  LuVolume2,
+  LuVolumeX,
+} from 'react-icons/lu';
 import { AutoSizingTextArea, Button, Icon, Label } from '../../../components';
 import IndexedDB from '../../../database/indexedDB';
 import { useFileUpload } from '../../../hooks/useFileUpload';
@@ -233,7 +249,9 @@ export default memo(function ChatMessage({
                 title={t('chatScreen.titles.previous')}
                 aria-label={t('chatScreen.ariaLabels.switchToPrevious')}
               >
-                <Icon icon="LuChevronLeft" size="sm" />
+                <Icon size="sm">
+                  <LuChevronLeft />
+                </Icon>
               </Button>
               <span>
                 {siblingCurrIdx + 1} / {siblingLeafNodeIds.length}
@@ -248,7 +266,9 @@ export default memo(function ChatMessage({
                 title={t('chatScreen.titles.next')}
                 aria-label={t('chatScreen.ariaLabels.switchToNext')}
               >
-                <Icon icon="LuChevronRight" size="sm" />
+                <Icon size="sm">
+                  <LuChevronRight />
+                </Icon>
               </Button>
             </div>
           )}
@@ -267,7 +287,9 @@ export default memo(function ChatMessage({
               title={t('chatScreen.titles.regenerate')}
               aria-label={t('chatScreen.ariaLabels.regenerateResponse')}
             >
-              <Icon icon="LuRefreshCw" size="sm" />
+              <Icon size="sm">
+                <LuRefreshCw />
+              </Icon>
             </Button>
           )}
 
@@ -280,7 +302,9 @@ export default memo(function ChatMessage({
               aria-label={t('chatScreen.ariaLabels.showPerformanceMetric')}
             >
               <div className="dropdown dropdown-hover dropdown-top">
-                <Icon icon="LuGauge" size="sm" />
+                <Icon size="sm">
+                  <LuGauge />
+                </Icon>
 
                 <div
                   tabIndex={0}
@@ -337,7 +361,9 @@ export default memo(function ChatMessage({
             title={t('chatScreen.titles.edit')}
             aria-label={t('chatScreen.ariaLabels.editMessage')}
           >
-            <Icon icon="LuSquarePen" size="sm" />
+            <Icon size="sm">
+              <LuSquarePen />
+            </Icon>
           </Button>
 
           {/* copy message */}
@@ -348,7 +374,9 @@ export default memo(function ChatMessage({
             title={t('chatScreen.titles.copy')}
             aria-label={t('chatScreen.ariaLabels.copyContent')}
           >
-            <Icon icon="LuCopy" size="sm" />
+            <Icon size="sm">
+              <LuCopy />
+            </Icon>
           </Button>
 
           {/* play message */}
@@ -370,7 +398,9 @@ export default memo(function ChatMessage({
             title={t('chatScreen.titles.delete')}
             aria-label={t('chatScreen.ariaLabels.deleteMessage')}
           >
-            <Icon icon="LuTrash2" size="sm" />
+            <Icon size="sm">
+              <LuTrash2 />
+            </Icon>
           </Button>
 
           {/* branch message */}
@@ -382,7 +412,9 @@ export default memo(function ChatMessage({
             title={t('chatScreen.titles.branchChat')}
             aria-label={t('chatScreen.ariaLabels.branchChatAfterMessage')}
           >
-            <Icon icon="LuGitMerge" size="sm" />
+            <Icon size="sm">
+              <LuGitMerge />
+            </Icon>
           </Button>
         </div>
       )}
@@ -433,7 +465,9 @@ function EditMessage({
               tabIndex={0}
               role="button"
             >
-              <Icon icon="LuPaperclip" size="md" />
+              <Icon size="md">
+                <LuPaperclip />
+              </Icon>
             </Label>
             <div className="grow" />
           </>
@@ -504,23 +538,30 @@ const ThinkingSection = memo(function ThinkingSection({
       <CollapsibleTrigger className="btn border-0 rounded-xl my-2 p-2 px-4">
         {isThinking && (
           <>
-            <Icon
-              icon="LuAtom"
-              size="md"
-              variant="leftside"
-              className="animate-spin"
-            />
+            <Icon size="md" variant="leftside" className="animate-spin">
+              <LuAtom />
+            </Icon>
             <Trans i18nKey="chatScreen.labels.thinking" />
           </>
         )}
         {!isThinking && (
           <>
-            <Icon icon="LuBrain" size="md" variant="leftside" />
+            <Icon size="md" variant="leftside">
+              <LuBrain />
+            </Icon>
             <Trans i18nKey="chatScreen.labels.thoughts" />
           </>
         )}
-        {!open && <Icon icon="LuChevronRight" size="md" variant="rightside" />}
-        {open && <Icon icon="LuChevronDown" size="md" variant="rightside" />}
+        {!open && (
+          <Icon size="md" variant="rightside">
+            <LuChevronRight />
+          </Icon>
+        )}
+        {open && (
+          <Icon size="md" variant="rightside">
+            <LuChevronDown />
+          </Icon>
+        )}
       </CollapsibleTrigger>
 
       <CollapsibleContent
@@ -573,7 +614,9 @@ const PlayButton = memo(function PlayButton({
               title={t('chatScreen.titles.play')}
               aria-label={t('chatScreen.ariaLabels.playMessage')}
             >
-              <Icon icon="LuVolume2" size="sm" />
+              <Icon size="sm">
+                <LuVolume2 />
+              </Icon>
             </Button>
           )}
           {isPlaying && (
@@ -586,7 +629,9 @@ const PlayButton = memo(function PlayButton({
               title={t('chatScreen.titles.stop')}
               aria-label={t('chatScreen.ariaLabels.stopMessage')}
             >
-              <Icon icon="LuVolumeX" size="sm" />
+              <Icon size="sm">
+                <LuVolumeX />
+              </Icon>
             </Button>
           )}
         </>

--- a/src/pages/Chat/components/MarkdownDisplay.tsx
+++ b/src/pages/Chat/components/MarkdownDisplay.tsx
@@ -2,6 +2,7 @@ import 'katex/dist/katex.min.css';
 import { all as languages } from 'lowlight';
 import React, { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuCopy, LuPlay } from 'react-icons/lu';
 import Markdown, { ExtraProps } from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeKatex from 'rehype-katex';
@@ -136,7 +137,9 @@ function CodeBlockToolbar({
           aria-label={t('chatScreen.ariaLabels.runCode')}
           onClick={handleRun}
         >
-          <Icon icon="LuPlay" size="sm" />
+          <Icon size="sm">
+            <LuPlay />
+          </Icon>
         </Button>
       )}
       <Button
@@ -146,7 +149,9 @@ function CodeBlockToolbar({
         aria-label={t('chatScreen.ariaLabels.copyContent')}
         onClick={handleCopy}
       >
-        <Icon icon="LuCopy" size="sm" />
+        <Icon size="sm">
+          <LuCopy />
+        </Icon>
       </Button>
     </div>
   );

--- a/src/pages/Settings/components/ImportExportComponent.tsx
+++ b/src/pages/Settings/components/ImportExportComponent.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { LuEye, LuMessageCircleMore } from 'react-icons/lu';
 import { TbDatabaseExport, TbDatabaseImport } from 'react-icons/tb';
 import { DelimeterComponent, SettingsSectionLabel } from '.';
 import { Button, Icon, Input, Label } from '../../../components';
@@ -37,7 +38,9 @@ export function ImportExportComponent({ onClose }: { onClose: () => void }) {
   return (
     <>
       <SettingsSectionLabel>
-        <Icon icon="LuMessageCircleMore" size="sm" variant="leftside" />
+        <Icon size="sm" variant="leftside">
+          <LuMessageCircleMore />
+        </Icon>
         {t('settings.importExport.chatsSectionTitle')}
       </SettingsSectionLabel>
 
@@ -69,7 +72,9 @@ export function ImportExportComponent({ onClose }: { onClose: () => void }) {
       <DelimeterComponent />
 
       <SettingsSectionLabel>
-        <Icon icon="LuEye" size="sm" variant="leftside" />
+        <Icon size="sm" variant="leftside">
+          <LuEye />
+        </Icon>
         {t('settings.importExport.technicalDemoSectionTitle')}
       </SettingsSectionLabel>
 

--- a/src/pages/Settings/components/PresetManager.tsx
+++ b/src/pages/Settings/components/PresetManager.tsx
@@ -1,4 +1,11 @@
 import { Trans, useTranslation } from 'react-i18next';
+import {
+  LuCirclePlay,
+  LuEllipsisVertical,
+  LuPencil,
+  LuSave,
+  LuTrash,
+} from 'react-icons/lu';
 import { SettingsSectionLabel } from '.';
 import { Button, Icon } from '../../../components';
 import { CONFIG_DEFAULT } from '../../../config';
@@ -96,7 +103,9 @@ export function PresetManager({
         title={t('settings.presetManager.buttons.save')}
         aria-label={t('settings.presetManager.ariaLabels.save')}
       >
-        <Icon icon="LuSave" size="md" />
+        <Icon size="md">
+          <LuSave />
+        </Icon>
         <Trans i18nKey="settings.presetManager.buttons.save" />
       </Button>
 
@@ -134,7 +143,9 @@ export function PresetManager({
                       title={t('settings.presetManager.buttons.load')}
                       aria-label={t('settings.presetManager.ariaLabels.load')}
                     >
-                      <Icon icon="LuCirclePlay" size="md" />
+                      <Icon size="md">
+                        <LuCirclePlay />
+                      </Icon>
                     </Button>
 
                     {/* dropdown */}
@@ -145,7 +156,9 @@ export function PresetManager({
                         title={t('settings.presetManager.buttons.more')}
                         aria-label={t('settings.presetManager.ariaLabels.more')}
                       >
-                        <Icon icon="LuEllipsisVertical" size="md" />
+                        <Icon size="md">
+                          <LuEllipsisVertical />
+                        </Icon>
                       </Button>
 
                       {/* dropdown menu */}
@@ -164,11 +177,9 @@ export function PresetManager({
                               'settings.presetManager.ariaLabels.rename'
                             )}
                           >
-                            <Icon
-                              icon="LuPencil"
-                              size="sm"
-                              variant="leftside"
-                            />
+                            <Icon size="sm" variant="leftside">
+                              <LuPencil />
+                            </Icon>
                             {t('settings.presetManager.buttons.rename')}
                           </Button>
                         </li>
@@ -181,7 +192,9 @@ export function PresetManager({
                               'settings.presetManager.ariaLabels.delete'
                             )}
                           >
-                            <Icon icon="LuTrash" size="sm" variant="leftside" />
+                            <Icon size="sm" variant="leftside">
+                              <LuTrash />
+                            </Icon>
                             {t('settings.presetManager.buttons.delete')}
                           </Button>
                         </li>

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -6,6 +6,27 @@ import React, {
   useState,
 } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import {
+  LuAudioLines,
+  LuBookmark,
+  LuBrain,
+  LuCog,
+  LuCpu,
+  LuDatabase,
+  LuFilter,
+  LuFlaskConical,
+  LuGrid2X2Plus,
+  LuHand,
+  LuMessageCircleMore,
+  LuMessagesSquare,
+  LuMonitor,
+  LuRefreshCw,
+  LuRocket,
+  LuSettings,
+  LuSpeech,
+  LuVolume2,
+  LuVolumeX,
+} from 'react-icons/lu';
 import { useNavigate } from 'react-router';
 import { Button, Dropdown, Icon } from '../../components';
 import { CONFIG_DEFAULT, INFERENCE_PROVIDERS } from '../../config';
@@ -115,7 +136,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuSettings" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuSettings />
+          </Icon>
           {t('settings.tabs.general')}
         </>
       ),
@@ -161,14 +184,18 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuMonitor" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuMonitor />
+          </Icon>
           {t('settings.tabs.ui')}
         </>
       ),
       fields: [
         toSection(
           t('settings.sections.userInterface'),
-          <Icon icon="LuMonitor" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuMonitor />
+          </Icon>
         ),
         toInput(SettingInputType.SHORT_INPUT, 'initials'),
         {
@@ -190,7 +217,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuAudioLines" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuAudioLines />
+          </Icon>
           {t('settings.tabs.voice')}
         </>
       ),
@@ -198,7 +227,9 @@ function getSettingTabsConfiguration(
         /* Text to Speech */
         toSection(
           t('settings.sections.textToSpeech'),
-          <Icon icon="LuSpeech" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuSpeech />
+          </Icon>
         ),
         toDropdown(
           'ttsVoice',
@@ -259,10 +290,14 @@ function getSettingTabsConfiguration(
                   aria-label="Play test message"
                 >
                   {!isPlaying && (
-                    <Icon icon="LuVolume2" size="sm" variant="leftside" />
+                    <Icon size="sm" variant="leftside">
+                      <LuVolume2 />
+                    </Icon>
                   )}
                   {isPlaying && (
-                    <Icon icon="LuVolumeX" size="sm" variant="leftside" />
+                    <Icon size="sm" variant="leftside">
+                      <LuVolumeX />
+                    </Icon>
                   )}
                   {t('settings.textToSpeech.check.label')}
                 </Button>
@@ -277,14 +312,18 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuMessagesSquare" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuMessagesSquare />
+          </Icon>
           {t('settings.tabs.conversations')}
         </>
       ),
       fields: [
         toSection(
           t('settings.sections.chat'),
-          <Icon icon="LuMessageCircleMore" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuMessageCircleMore />
+          </Icon>
         ),
         toInput(SettingInputType.SHORT_INPUT, 'pasteLongTextToFileLen'),
         toInput(SettingInputType.CHECKBOX, 'pdfAsImage'),
@@ -293,7 +332,9 @@ function getSettingTabsConfiguration(
         DELIMITER,
         toSection(
           t('settings.sections.performance'),
-          <Icon icon="LuRocket" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuRocket />
+          </Icon>
         ),
         toInput(SettingInputType.CHECKBOX, 'showTokensPerSecond'),
 
@@ -301,7 +342,9 @@ function getSettingTabsConfiguration(
         DELIMITER,
         toSection(
           t('settings.sections.reasoning'),
-          <Icon icon="LuBrain" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuBrain />
+          </Icon>
         ),
         toInput(SettingInputType.CHECKBOX, 'showThoughtInProgress'),
         toInput(SettingInputType.CHECKBOX, 'excludeThoughtOnReq'),
@@ -312,7 +355,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuBookmark" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuBookmark />
+          </Icon>
           {t('settings.tabs.presets')}
         </>
       ),
@@ -329,7 +374,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuDatabase" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuDatabase />
+          </Icon>
           {t('settings.tabs.importExport')}
         </>
       ),
@@ -346,7 +393,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuGrid2X2Plus" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuGrid2X2Plus />
+          </Icon>
           {t('settings.tabs.advanced')}
         </>
       ),
@@ -354,7 +403,9 @@ function getSettingTabsConfiguration(
         /* Generation */
         toSection(
           t('settings.sections.generation'),
-          <Icon icon="LuCog" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuCog />
+          </Icon>
         ),
         toInput(SettingInputType.CHECKBOX, 'overrideGenerationOptions'),
         ...['temperature', 'top_k', 'top_p', 'min_p', 'max_tokens'].map((key) =>
@@ -369,7 +420,9 @@ function getSettingTabsConfiguration(
         DELIMITER,
         toSection(
           t('settings.sections.samplers'),
-          <Icon icon="LuFilter" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuFilter />
+          </Icon>
         ),
         toInput(SettingInputType.CHECKBOX, 'overrideSamplersOptions'),
         ...[
@@ -391,7 +444,9 @@ function getSettingTabsConfiguration(
         DELIMITER,
         toSection(
           t('settings.sections.penalties'),
-          <Icon icon="LuHand" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuHand />
+          </Icon>
         ),
         toInput(SettingInputType.CHECKBOX, 'overridePenaltyOptions'),
         ...[
@@ -415,7 +470,9 @@ function getSettingTabsConfiguration(
         DELIMITER,
         toSection(
           t('settings.sections.custom'),
-          <Icon icon="LuCpu" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuCpu />
+          </Icon>
         ),
         toInput(SettingInputType.LONG_INPUT, 'custom'),
       ],
@@ -425,7 +482,9 @@ function getSettingTabsConfiguration(
     {
       title: (
         <>
-          <Icon icon="LuFlaskConical" size="sm" variant="leftside" />
+          <Icon size="sm" variant="leftside">
+            <LuFlaskConical />
+          </Icon>
           <Trans i18nKey="settings.sections.experimental" />
         </>
       ),
@@ -672,7 +731,9 @@ export default function Settings() {
                   )
                 }
               >
-                <Icon icon="LuRefreshCw" size="sm" variant="leftside" />
+                <Icon size="sm" variant="leftside">
+                  <LuRefreshCw />
+                </Icon>
                 <Trans i18nKey="settings.actionButtons.fetchModels" />
               </Button>
             );


### PR DESCRIPTION
- Replace string-based icon names with direct React icon components
- Update all components to use inline icon elements instead of icon prop